### PR TITLE
Fix: make hax skip RNG functions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -66,8 +66,8 @@ jobs:
     needs: unit-tests
     runs-on: ubuntu-latest
     if: >-
-      (github.event_name == 'workflow_dispatch') ||
-      (github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags'))
+      vars.SHOULD_GENERATE_FSTAR == 1 &&
+      ((github.event_name == 'workflow_dispatch') || (github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')))
 
     steps:
     - name: Checkout edhoc-rs


### PR DESCRIPTION
Adjust `generate-fstar` CI action, now that [hax#276](https://github.com/hacspec/hax/issues/276) is fixed.