### PR TITLE
python: Provide documentation URI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ resolver = "2"
 
 [workspace.package]
 version = "0.8.0"
-repository = "https://github.com/openwsn-berkeley/lakers/"
+repository = "https://github.com/lake-rs/lakers/"
 license = "BSD-3-Clause"
 readme = "shared/README.md"
 keywords = ["iot", "security", "protocol", "crypto", "edhoc"]

--- a/crypto/lakers-crypto-rustcrypto/src/lib.rs
+++ b/crypto/lakers-crypto-rustcrypto/src/lib.rs
@@ -132,7 +132,7 @@ impl<Rng: rand_core::RngCore + rand_core::CryptoRng> CryptoTrait for Crypto<Rng>
             1.into(), /* Y coordinate choice does not matter for ECDH operation */
         )
         // While this can actually panic so far, the proper fix is in
-        // https://github.com/openwsn-berkeley/lakers/issues/93 which will justify this to be a
+        // https://github.com/lake-rs/lakers/issues/93 which will justify this to be a
         // panic (because after that, public key validity will be an invariant of the public key
         // type)
         .expect("Public key is not a good point");

--- a/examples/lakers-c-riot/README.md
+++ b/examples/lakers-c-riot/README.md
@@ -12,6 +12,6 @@ Add `EDHOC_CRYPTO=psa` if you want the `crypto-psa-baremetal` configuration.
 # Requirements
 
 - `lakers-c` library and headers:
-  - either download them from the [releases page on GitHub](https://github.com/openwsn-berkeley/lakers/releases)
+  - either download them from the [releases page on GitHub](https://github.com/lake-rs/lakers/releases)
   - or build yourself following the README in the `lakers-c` crate
 - [RIOT](https://github.com/RIOT-OS/RIOT)'s source code must be available in a local folder, which can be set via the `RIOTBASE` variable.

--- a/lakers-python/Cargo.toml
+++ b/lakers-python/Cargo.toml
@@ -4,6 +4,7 @@ edition = "2021"
 version ="0.5.0"
 repository.workspace = true
 license.workspace = true
+description = "An implementation of EDHOC, written in Rust"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/lakers-python/README.md
+++ b/lakers-python/README.md
@@ -1,5 +1,5 @@
 # Lakers Python
-Python wrapper for the [`lakers` crate](https://github.com/openwsn-berkeley/lakers).
+Python wrapper for the [`lakers` crate](https://github.com/lake-rs/lakers).
 
 # Installation and usage
 

--- a/lakers-python/doc/index.rst
+++ b/lakers-python/doc/index.rst
@@ -8,7 +8,7 @@ Documentation on the underlying Rust library is found `on docs.rs`_.
 
 See the project README_ file for installation, maintenance and license information.
 
-.. _README: https://github.com/openwsn-berkeley/lakers/blob/main/lakers-python/README.md
+.. _README: https://github.com/lake-rs/lakers/blob/main/lakers-python/README.md
 .. _lakers-python: https://pypi.org/project/lakers-python/
 .. _`on docs.rs`: https://docs.rs/lakers/
 

--- a/lakers-python/pyproject.toml
+++ b/lakers-python/pyproject.toml
@@ -4,3 +4,11 @@ build-backend = "maturin"
 
 [tool.maturin]
 include = ["./examples/*"]
+
+[project]
+name = "lakers-python"
+dynamic = ["version"]
+
+[project.urls]
+"Source Code" = "https://github.com/lake-rs/lakers/tree/main/lakers-python"
+Documentation = "https://lakers.readthedocs.io/"

--- a/lib/README.md
+++ b/lib/README.md
@@ -1,7 +1,7 @@
 # lakers &emsp; [![CI status]][actions] [![Latest Version]][crates.io] [![API Documentation]][docs.rs]
 
-[CI status]: https://github.com/openwsn-berkeley/lakers/actions/workflows/build-and-test.yml/badge.svg
-[actions]: https://github.com/openwsn-berkeley/lakers/actions/workflows/build-and-test.yml
+[CI status]: https://github.com/lake-rs/lakers/actions/workflows/build-and-test.yml/badge.svg
+[actions]: https://github.com/lake-rs/lakers/actions/workflows/build-and-test.yml
 [Latest Version]: https://img.shields.io/crates/v/lakers.svg
 [crates.io]: https://crates.io/crates/lakers
 [API Documentation]: https://docs.rs/lakers/badge.svg
@@ -26,7 +26,7 @@ Ephemeral Diffie-Hellman Over COSE (EDHOC) is a new IETF standard that provides 
 - easy to use, typestated API for Initiator and Responder
 - microcontroller-optimized: `no_std`, no heap allocations, zero-dependencies (other than crypto backends)
 - configurable crypto backends
-- bindings for [C](https://github.com/openwsn-berkeley/lakers/releases/) and [Python](https://pypi.org/project/lakers-python/)
+- bindings for [C](https://github.com/lake-rs/lakers/releases/) and [Python](https://pypi.org/project/lakers-python/)
 - support for EDHOC extensions, including [zero-touch authorization](https://datatracker.ietf.org/doc/draft-ietf-lake-authz/)
 
 It currently supports authentication mode STAT-STAT and Cipher Suite 2 (AES-CCM-16-64-128, SHA-256, 8, P-256, ES256, AES-CCM-16-64-128, SHA-256).
@@ -57,7 +57,7 @@ let prk_out_new = initiator.edhoc_key_update(context);
 ```
 
 ### C API
-C-compatible static libraries and headers are available for download in [the releases page](https://github.com/openwsn-berkeley/lakers/releases).
+C-compatible static libraries and headers are available for download in [the releases page](https://github.com/lake-rs/lakers/releases).
 
 ### Python API
 `lakers-python` is [available on PyPI](https://pypi.org/project/lakers-python/), to install it run `pip install lakers-python`.
@@ -69,7 +69,7 @@ To work on `lakers` itself, follow the instructions below:
 
 2. Download, compile, and run the tests:
 ```
-git clone git@github.com:openwsn-berkeley/lakers.git && cd lakers
+git clone git@github.com:lake-rs/lakers.git && cd lakers
 cargo build
 cargo test
 ```


### PR DESCRIPTION
I'm not 100% sure all the settings are right, but this does produce a PKG-INFO in the source tar ball that has a `Project-URL: Documentation, …` added, and has a description. ([Docs](https://www.maturin.rs/metadata) indicate that adding a dynamic on project_url should also give the right results, but I'm not sure what we'd have to set for that).

Follow-up-for: https://github.com/openwsn-berkeley/lakers/pull/351