### PR TITLE
Update pyo3

### DIFF
--- a/lakers-python/Cargo.toml
+++ b/lakers-python/Cargo.toml
@@ -9,13 +9,13 @@ description = "An implementation of EDHOC, written in Rust"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-pyo3 = { version = "0.22", features = ["extension-module"] }
+pyo3 = { version = "0.23", features = ["extension-module"] }
 lakers = { package = "lakers", path = "../lib", default-features = false, features = [ "log" ] }
 lakers-ead-authz = { path = "../ead/lakers-ead-authz", features = [ "log" ] }
 lakers-shared = { path = "../shared", features = ["python-bindings", "large_buffers"] }
 lakers-crypto = { path = "../crypto", default-features = false, features = ["rustcrypto"] }
 log = "0.4"
-pyo3-log = "0.11.0"
+pyo3-log = "0.12.0"
 
 [dev-dependencies]
 # We don't need it to build, but it is listed in the manifest Cargo.toml, and

--- a/lakers-python/Cargo.toml
+++ b/lakers-python/Cargo.toml
@@ -9,7 +9,7 @@ description = "An implementation of EDHOC, written in Rust"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-pyo3 = { version = "0.23", features = ["extension-module"] }
+pyo3 = { version = "0.25", features = ["extension-module"] }
 lakers = { package = "lakers", path = "../lib", default-features = false, features = [ "log" ] }
 lakers-ead-authz = { path = "../ead/lakers-ead-authz", features = [ "log" ] }
 lakers-shared = { path = "../shared", features = ["python-bindings", "large_buffers"] }

--- a/lakers-python/src/ead_authz/authenticator.rs
+++ b/lakers-python/src/ead_authz/authenticator.rs
@@ -35,8 +35,8 @@ impl PyAuthzAutenticator {
         self.authenticator_wait = state;
         let loc_w = std::str::from_utf8(loc_w.as_slice()).unwrap();
         Ok((
-            PyString::new_bound(py, loc_w),
-            PyBytes::new_bound(py, voucher_request.as_slice()),
+            PyString::new(py, loc_w),
+            PyBytes::new(py, voucher_request.as_slice()),
         ))
     }
 

--- a/lakers-python/src/ead_authz/device.rs
+++ b/lakers-python/src/ead_authz/device.rs
@@ -61,6 +61,6 @@ impl PyAuthzDevice {
     }
 
     pub fn get_g_w<'a>(&self, py: Python<'a>) -> PyResult<Bound<'a, PyBytes>> {
-        Ok(PyBytes::new_bound(py, &self.device.g_w[..]))
+        Ok(PyBytes::new(py, &self.device.g_w[..]))
     }
 }

--- a/lakers-python/src/ead_authz/server.rs
+++ b/lakers-python/src/ead_authz/server.rs
@@ -38,7 +38,7 @@ impl PyAuthzEnrollmentServer {
             .server
             .handle_voucher_request(&mut default_crypto(), &vreq)
         {
-            Ok(voucher_response) => Ok(PyBytes::new_bound(py, voucher_response.as_slice())),
+            Ok(voucher_response) => Ok(PyBytes::new(py, voucher_response.as_slice())),
             Err(error) => Err(error.into()),
         }
     }
@@ -72,7 +72,7 @@ impl PyAuthzServerUserAcl {
             .server
             .decode_voucher_request(&mut default_crypto(), &vreq)
         {
-            Ok(id_u) => Ok(PyBytes::new_bound(py, id_u.as_slice())),
+            Ok(id_u) => Ok(PyBytes::new(py, id_u.as_slice())),
             Err(error) => Err(error.into()),
         }
     }
@@ -80,7 +80,7 @@ impl PyAuthzServerUserAcl {
     fn prepare_voucher<'a>(&self, py: Python<'a>, vreq: Vec<u8>) -> PyResult<Bound<'a, PyBytes>> {
         let vreq = EdhocMessageBuffer::new_from_slice(vreq.as_slice()).unwrap();
         match self.server.prepare_voucher(&mut default_crypto(), &vreq) {
-            Ok(voucher_response) => Ok(PyBytes::new_bound(py, voucher_response.as_slice())),
+            Ok(voucher_response) => Ok(PyBytes::new(py, voucher_response.as_slice())),
             Err(error) => Err(error.into()),
         }
     }

--- a/lakers-python/src/initiator.rs
+++ b/lakers-python/src/initiator.rs
@@ -93,7 +93,7 @@ impl PyEdhocInitiator {
         let (state, message_1) =
             i_prepare_message_1(&self.start, &mut default_crypto(), c_i, &ead_1)?;
         self.wait_m2 = Some(state);
-        Ok(PyBytes::new_bound(py, message_1.as_slice()))
+        Ok(PyBytes::new(py, message_1.as_slice()))
     }
 
     /// Process message 2.
@@ -114,8 +114,8 @@ impl PyEdhocInitiator {
             i_parse_message_2(&self.take_wait_m2()?, &mut default_crypto(), &message_2)?;
         self.processing_m2 = Some(state);
         Ok((
-            PyBytes::new_bound(py, c_r.as_slice()),
-            PyBytes::new_bound(py, id_cred_r.bytes.as_slice()),
+            PyBytes::new(py, c_r.as_slice()),
+            PyBytes::new(py, id_cred_r.bytes.as_slice()),
             ead_2,
         ))
     }
@@ -174,8 +174,8 @@ impl PyEdhocInitiator {
         )?;
         self.wait_m4 = Some(state);
         Ok((
-            PyBytes::new_bound(py, message_3.as_slice()),
-            PyBytes::new_bound(py, prk_out.as_slice()),
+            PyBytes::new(py, message_3.as_slice()),
+            PyBytes::new(py, prk_out.as_slice()),
         ))
     }
 
@@ -215,7 +215,7 @@ impl PyEdhocInitiator {
         length: usize,
     ) -> PyResult<Bound<'a, PyBytes>> {
         let completed = self.as_mut_completed()?;
-        PyBytes::new_bound_with(py, length, |output| {
+        PyBytes::new_with(py, length, |output| {
             Ok(edhoc_exporter(
                 completed,
                 &mut default_crypto(),
@@ -237,14 +237,11 @@ impl PyEdhocInitiator {
             &mut default_crypto(),
             context.as_slice(),
         );
-        Ok(PyBytes::new_bound(py, &res[..SHA256_DIGEST_LEN]))
+        Ok(PyBytes::new(py, &res[..SHA256_DIGEST_LEN]))
     }
 
     pub fn get_h_message_1<'a>(&self, py: Python<'a>) -> PyResult<Bound<'a, PyBytes>> {
-        Ok(PyBytes::new_bound(
-            py,
-            &self.as_ref_wait_m2()?.h_message_1[..],
-        ))
+        Ok(PyBytes::new(py, &self.as_ref_wait_m2()?.h_message_1[..]))
     }
 
     pub fn compute_ephemeral_secret<'a>(
@@ -255,7 +252,7 @@ impl PyEdhocInitiator {
         let mut g_a_arr = BytesP256ElemLen::default();
         g_a_arr.copy_from_slice(&g_a[..]);
         let secret = default_crypto().p256_ecdh(&self.start.x, &g_a_arr);
-        Ok(PyBytes::new_bound(py, &secret[..]))
+        Ok(PyBytes::new(py, &secret[..]))
     }
 
     /// The cipher suite that is agreed on by the exchange.

--- a/lakers-python/src/lib.rs
+++ b/lakers-python/src/lib.rs
@@ -94,7 +94,7 @@ pub fn py_credential_check_or_fetch<'a>(
         IdCred::from_full_value(id_cred_received.as_slice())?,
     )?;
 
-    Ok(PyBytes::new_bound(py, valid_cred.bytes.as_slice()))
+    Ok(PyBytes::new(py, valid_cred.bytes.as_slice()))
 }
 
 /// this function is useful to test the python bindings
@@ -104,8 +104,8 @@ fn p256_generate_key_pair<'a>(
 ) -> PyResult<(Bound<'a, PyBytes>, Bound<'a, PyBytes>)> {
     let (x, g_x) = default_crypto().p256_generate_key_pair();
     Ok((
-        PyBytes::new_bound(py, x.as_slice()),
-        PyBytes::new_bound(py, g_x.as_slice()),
+        PyBytes::new(py, x.as_slice()),
+        PyBytes::new(py, g_x.as_slice()),
     ))
 }
 
@@ -167,7 +167,7 @@ fn lakers_python(py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<ead_authz::PyAuthzEnrollmentServer>()?;
     m.add_class::<ead_authz::PyAuthzServerUserAcl>()?;
 
-    let submodule = PyModule::new_bound(py, "consts")?;
+    let submodule = PyModule::new(py, "consts")?;
     submodule.add("EAD_AUTHZ_LABEL", lakers_ead_authz::consts::EAD_AUTHZ_LABEL)?;
     m.add_submodule(&submodule)?;
     Ok(())

--- a/lakers-python/src/responder.rs
+++ b/lakers-python/src/responder.rs
@@ -84,7 +84,7 @@ impl PyEdhocResponder {
         let (state, c_i, ead_1) =
             r_process_message_1(&self.take_start()?, &mut default_crypto(), &message_1)?;
         self.processing_m1 = Some(state);
-        let c_i = PyBytes::new_bound(py, c_i.as_slice());
+        let c_i = PyBytes::new(py, c_i.as_slice());
 
         Ok((c_i, ead_1))
     }
@@ -121,7 +121,7 @@ impl PyEdhocResponder {
             &ead_2,
         )?;
         self.wait_m3 = Some(state);
-        Ok(PyBytes::new_bound(py, message_2.as_slice()))
+        Ok(PyBytes::new(py, message_2.as_slice()))
     }
 
     /// Processes message 3.
@@ -140,7 +140,7 @@ impl PyEdhocResponder {
         let (state, id_cred_i, ead_3) =
             r_parse_message_3(&mut self.take_wait_m3()?, &mut default_crypto(), &message_3)?;
         self.processing_m3 = Some(state);
-        Ok((PyBytes::new_bound(py, id_cred_i.bytes.as_slice()), ead_3))
+        Ok((PyBytes::new(py, id_cred_i.bytes.as_slice()), ead_3))
     }
 
     /// Verifies the previously inserted message 3.
@@ -161,7 +161,7 @@ impl PyEdhocResponder {
             valid_cred_i,
         )?;
         self.processed_m3 = Some(state);
-        Ok(PyBytes::new_bound(py, prk_out.as_slice()))
+        Ok(PyBytes::new(py, prk_out.as_slice()))
     }
 
     /// Generates a message 4.
@@ -179,7 +179,7 @@ impl PyEdhocResponder {
         let (state, message_4) =
             r_prepare_message_4(&self.take_processed_m3()?, &mut default_crypto(), &ead_4)?;
         self.completed = Some(state);
-        Ok(PyBytes::new_bound(py, message_4.as_slice()))
+        Ok(PyBytes::new(py, message_4.as_slice()))
     }
 
     /// Declares the protocol to have completed without any message 4.
@@ -201,7 +201,7 @@ impl PyEdhocResponder {
         length: usize,
     ) -> PyResult<Bound<'a, PyBytes>> {
         let completed = self.as_mut_completed()?;
-        PyBytes::new_bound_with(py, length, |output| {
+        PyBytes::new_with(py, length, |output| {
             Ok(edhoc_exporter(
                 completed,
                 &mut default_crypto(),
@@ -223,7 +223,7 @@ impl PyEdhocResponder {
             &mut default_crypto(),
             context.as_slice(),
         );
-        Ok(PyBytes::new_bound(py, &res[..SHA256_DIGEST_LEN]))
+        Ok(PyBytes::new(py, &res[..SHA256_DIGEST_LEN]))
     }
 }
 

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -12,7 +12,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-pyo3 = { version = "0.23", features = ["extension-module"], optional = true }
+pyo3 = { version = "0.25", features = ["extension-module"], optional = true }
 hex = { version = "0.4.3", optional = true }
 defmt-or-log = { version = "0.2.1", default-features = false }
 log = { version = "0.4", optional = true }

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -12,7 +12,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-pyo3 = { version = "0.22", features = ["extension-module"], optional = true }
+pyo3 = { version = "0.23", features = ["extension-module"], optional = true }
 hex = { version = "0.4.3", optional = true }
 defmt-or-log = { version = "0.2.1", default-features = false }
 log = { version = "0.4", optional = true }

--- a/shared/src/python_bindings.rs
+++ b/shared/src/python_bindings.rs
@@ -46,9 +46,7 @@ impl EADItem {
     }
 
     fn value<'a>(&self, py: Python<'a>) -> Option<Bound<'a, PyBytes>> {
-        self.value
-            .as_ref()
-            .map(|v| PyBytes::new_bound(py, v.as_slice()))
+        self.value.as_ref().map(|v| PyBytes::new(py, v.as_slice()))
     }
 
     fn label(&self) -> u16 {
@@ -75,8 +73,9 @@ impl<'a, 'py> pyo3::conversion::FromPyObject<'py> for EadItems {
 
 impl pyo3::conversion::IntoPy<PyObject> for EadItems {
     fn into_py(self, py: Python<'_>) -> PyObject {
-        let list = pyo3::types::PyList::new_bound(py, core::iter::empty::<PyObject>());
-        // Can't pass it into new_bound as it doesn't have an ExactSizeItertor -- FIXME: should we
+        let list = pyo3::types::PyList::new(py, core::iter::empty::<PyObject>())
+            .expect("No items are appended that could err");
+        // Can't pass it into new as it doesn't have an ExactSizeItertor -- FIXME: should we
         // implement and use that?
         for item in self.iter() {
             list.append(item.clone().into_py(py))
@@ -133,15 +132,15 @@ impl Credential {
     }
 
     fn value<'a>(&self, py: Python<'a>) -> Bound<'a, PyBytes> {
-        PyBytes::new_bound(py, self.bytes.as_slice())
+        PyBytes::new(py, self.bytes.as_slice())
     }
 
     #[pyo3(name = "public_key")]
     fn py_public_key<'a>(&self, py: Python<'a>) -> Bound<'a, PyBytes> {
-        PyBytes::new_bound(py, &self.public_key().unwrap())
+        PyBytes::new(py, &self.public_key().unwrap())
     }
 
     fn kid<'a>(&self, py: Python<'a>) -> Bound<'a, PyBytes> {
-        PyBytes::new_bound(py, self.kid.as_ref().unwrap().as_slice())
+        PyBytes::new(py, self.kid.as_ref().unwrap().as_slice())
     }
 }

--- a/shared/src/python_bindings.rs
+++ b/shared/src/python_bindings.rs
@@ -71,18 +71,19 @@ impl<'a, 'py> pyo3::conversion::FromPyObject<'py> for EadItems {
     }
 }
 
-impl pyo3::conversion::IntoPy<PyObject> for EadItems {
-    fn into_py(self, py: Python<'_>) -> PyObject {
-        let list = pyo3::types::PyList::new(py, core::iter::empty::<PyObject>())
-            .expect("No items are appended that could err");
+impl<'py> pyo3::conversion::IntoPyObject<'py> for EadItems {
+    type Target = pyo3::types::PyList;
+    type Output = Bound<'py, Self::Target>;
+    type Error = PyErr;
+
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        let list = pyo3::types::PyList::new(py, core::iter::empty::<PyObject>())?;
         // Can't pass it into new as it doesn't have an ExactSizeItertor -- FIXME: should we
         // implement and use that?
         for item in self.iter() {
-            list.append(item.clone().into_py(py))
-                // ... and we can't return an error here anyway.
-                .expect("Appending to a Python list does not realistically err");
+            list.append(item.clone())?;
         }
-        list.into()
+        Ok(list.into())
     }
 }
 

--- a/shared/src/python_bindings.rs
+++ b/shared/src/python_bindings.rs
@@ -62,7 +62,7 @@ impl<'a, 'py> pyo3::conversion::FromPyObject<'py> for EadItems {
     fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
         let mut items = EadItems::new();
         let value: &Bound<'py, pyo3::types::PySequence> = ob.downcast()?;
-        for item in value.iter()? {
+        for item in value.try_iter()? {
             items
                 .try_push(item?.extract()?)
                 .map_err(|err| PyValueError::new_err(format!("ead already full: {:?}", err)))?;


### PR DESCRIPTION
Our Python package is not compatible with the latest PyPy versions (and probably also not with upcoming Python versions) due to its old pyo3. ("error: the configured PyPy interpreter version (3.11) is newer than PyO3's maximum supported version (3.10)").

An update to pyo3 should fix this; that happens in two steps to get the benefits of deprecation warnings during development (and thus also in any bisection situation).