### PR TITLE
release: python 0.6.0

### DIFF
--- a/lakers-python/Cargo.toml
+++ b/lakers-python/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lakers-python" # this will be the name of the package on pypi
 edition = "2021"
-version ="0.5.0"
+version ="0.6.0"
 repository.workspace = true
 license.workspace = true
 description = "An implementation of EDHOC, written in Rust"


### PR DESCRIPTION
Changes since 0.5.0:

* Breaking: EAD items are now lists of items rather than a single item (with None still accepted, equivalent to [])
* Updated PyO3 for compatibiltiy with Python 3.14
* Reduced use of internal buffering
* Added documentation
* Improved exception texts, particularly on state violations
* Various improvements from the underlying lakers library

---

The latest important PRs that are in are in are #383 and #385; this unblocks aiocoap's CI for going towards 3.14 and also more recent PyPy versions.