### PR TITLE
python: release as 0.6.2

### DIFF
--- a/lakers-python/Cargo.toml
+++ b/lakers-python/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lakers-python" # this will be the name of the package on pypi
 edition = "2021"
-version ="0.6.1"
+version ="0.6.2"
 repository.workspace = true
 license.workspace = true
 description = "An implementation of EDHOC, written in Rust"

--- a/lakers-python/doc/CHANGELOG.md
+++ b/lakers-python/doc/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## lakers-python-v0.6.2
+
+### Changed
+
+* EAD parsing was fixed: it previously misrepresented EAD items after value-less EAD items.
+* Log messages from the lakers-shared crate are now available in Python.
+
 ## lakers-python-v0.6.1
 
 ### Added


### PR DESCRIPTION
It's a small release, but it'll allow using aiocoap as a testing platform for grease-testing other implementations (at least EAD-wise).