### PR TITLE
Update example for nRF52840

### DIFF
--- a/examples/lakers-nrf52840/.cargo/config.toml
+++ b/examples/lakers-nrf52840/.cargo/config.toml
@@ -1,6 +1,7 @@
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
 # replace nRF82840_xxAA with your chip as listed in `probe-rs chip list`
-runner = "probe-rs run --chip nRF52840_xxAA"
+runner = ["probe-rs", "run", "--chip", "nRF52840_xxAA", "--log-format=oneline", "--allow-erase-all", "--verify"]
+
 
 [build]
 target = "thumbv7em-none-eabihf"

--- a/examples/lakers-nrf52840/src/bin/initiator.rs
+++ b/examples/lakers-nrf52840/src/bin/initiator.rs
@@ -15,6 +15,7 @@ use {defmt_rtt as _, panic_probe as _};
 
 use lakers::*;
 use lakers_crypto::{default_crypto, CryptoTrait};
+use lakers_nrf52840;
 
 extern crate alloc;
 
@@ -28,8 +29,6 @@ static HEAP: Heap = Heap::empty();
 extern "C" {
     pub fn mbedtls_memory_buffer_alloc_init(buf: *mut c_char, len: usize);
 }
-
-mod common;
 
 bind_interrupts!(struct Irqs {
     RADIO => radio::InterruptHandler<peripherals::RADIO>;
@@ -49,12 +48,12 @@ async fn main(spawner: Spawner) {
 
     radio.set_mode(Mode::BLE_1MBIT);
     radio.set_tx_power(TxPower::_0D_BM);
-    radio.set_frequency(common::FREQ);
+    radio.set_frequency(lakers_nrf52840::FREQ);
 
-    radio.set_access_address(common::ADV_ADDRESS);
+    radio.set_access_address(lakers_nrf52840::ADV_ADDRESS);
     radio.set_header_expansion(false);
-    radio.set_crc_init(common::ADV_CRC_INIT);
-    radio.set_crc_poly(common::CRC_POLY);
+    radio.set_crc_init(lakers_nrf52840::ADV_CRC_INIT);
+    radio.set_crc_poly(lakers_nrf52840::CRC_POLY);
 
     info!("init_handshake");
 
@@ -66,24 +65,24 @@ async fn main(spawner: Spawner) {
         mbedtls_memory_buffer_alloc_init(buffer.as_mut_ptr(), buffer.len());
     }
 
-    let cred_i = Credential::parse_ccs(common::CRED_I.try_into().unwrap()).unwrap();
-    let cred_r = Credential::parse_ccs(common::CRED_R.try_into().unwrap()).unwrap();
+    let cred_i = Credential::parse_ccs(lakers_nrf52840::CRED_I.try_into().unwrap()).unwrap();
+    let cred_r = Credential::parse_ccs(lakers_nrf52840::CRED_R.try_into().unwrap()).unwrap();
 
     let mut initiator = EdhocInitiator::new(
         lakers_crypto::default_crypto(),
         EDHOCMethod::StatStat,
         EDHOCSuite::CipherSuite2,
     );
-    initiator.set_identity(common::I.try_into().unwrap(), cred_i);
+    initiator.set_identity(lakers_nrf52840::I.try_into().unwrap(), cred_i);
 
     // Send Message 1 over raw BLE and convert the response to byte
     let c_i = generate_connection_identifier_cbor(&mut lakers_crypto::default_crypto());
     let (initiator, message_1) = initiator
         .prepare_message_1(Some(c_i), &EadItems::new())
         .unwrap();
-    let pckt_1 = common::Packet::new_from_slice(message_1.as_slice(), Some(0xf5))
+    let pckt_1 = lakers_nrf52840::Packet::new_from_slice(message_1.as_slice(), Some(0xf5))
         .expect("Buffer not long enough");
-    let rcvd = common::transmit_and_wait_response(&mut radio, pckt_1, Some(0xf5)).await;
+    let rcvd = lakers_nrf52840::transmit_and_wait_response(&mut radio, pckt_1, Some(0xf5)).await;
 
     match rcvd {
         Ok(pckt_2) => {
@@ -99,13 +98,18 @@ async fn main(spawner: Spawner) {
             let (mut initiator, message_3, i_prk_out) = initiator
                 .prepare_message_3(CredentialTransfer::ByReference, &EadItems::new())
                 .unwrap();
-            let pckt_3 =
-                common::Packet::new_from_slice(message_3.as_slice(), Some(c_r.as_slice()[0]))
-                    .expect("Buffer not long enough");
+            let pckt_3 = lakers_nrf52840::Packet::new_from_slice(
+                message_3.as_slice(),
+                Some(c_r.as_slice()[0]),
+            )
+            .expect("Buffer not long enough");
             info!("Send message_3 and wait message_4");
-            let rcvd =
-                common::transmit_and_wait_response(&mut radio, pckt_3, Some(c_r.as_slice()[0]))
-                    .await;
+            let rcvd = lakers_nrf52840::transmit_and_wait_response(
+                &mut radio,
+                pckt_3,
+                Some(c_r.as_slice()[0]),
+            )
+            .await;
 
             info!("Sent message_3");
             match rcvd {

--- a/examples/lakers-nrf52840/src/bin/initiator.rs
+++ b/examples/lakers-nrf52840/src/bin/initiator.rs
@@ -2,19 +2,15 @@
 #![no_main]
 
 use defmt::info;
-use defmt::unwrap;
 use embassy_executor::Spawner;
 use embassy_nrf::gpio::{Level, Output, OutputDrive};
 use embassy_nrf::radio::ble::Mode;
 use embassy_nrf::radio::ble::Radio;
 use embassy_nrf::radio::TxPower;
 use embassy_nrf::{bind_interrupts, peripherals, radio};
-use embassy_time::WithTimeout;
-use embassy_time::{Duration, Timer};
 use {defmt_rtt as _, panic_probe as _};
 
 use lakers::*;
-use lakers_crypto::{default_crypto, CryptoTrait};
 use lakers_nrf52840;
 
 extern crate alloc;
@@ -35,7 +31,7 @@ bind_interrupts!(struct Irqs {
 });
 
 #[embassy_executor::main]
-async fn main(spawner: Spawner) {
+async fn main(_spawner: Spawner) {
     let mut config = embassy_nrf::config::Config::default();
     config.hfclk_source = embassy_nrf::config::HfclkSource::ExternalXtal;
     let peripherals = embassy_nrf::init(config);
@@ -90,12 +86,13 @@ async fn main(spawner: Spawner) {
             let message_2: EdhocMessageBuffer =
                 // starts in 1 to consider only the content and not the metadata
                 pckt_2.pdu[1..pckt_2.len].try_into().expect("wrong length");
-            info!("message_2 :{:?}", message_2.content);
-            let (initiator, c_r, id_cred_r, ead_2) = initiator.parse_message_2(&message_2).unwrap();
+            info!("message_2 :{:?}", message_2.as_slice());
+            let (initiator, c_r, id_cred_r, _ead_2) =
+                initiator.parse_message_2(&message_2).unwrap();
             let valid_cred_r = credential_check_or_fetch(Some(cred_r), id_cred_r).unwrap();
             let initiator = initiator.verify_message_2(valid_cred_r).unwrap();
 
-            let (mut initiator, message_3, i_prk_out) = initiator
+            let (initiator, message_3, i_prk_out) = initiator
                 .prepare_message_3(CredentialTransfer::ByReference, &EadItems::new())
                 .unwrap();
             let pckt_3 = lakers_nrf52840::Packet::new_from_slice(
@@ -118,7 +115,7 @@ async fn main(spawner: Spawner) {
                     let message_4: EdhocMessageBuffer =
                         pckt_4.pdu[1..pckt_4.len].try_into().expect("wrong length");
 
-                    let (initiator, ead_4) = initiator.process_message_4(&message_4).unwrap();
+                    let (_initiator, _ead_4) = initiator.process_message_4(&message_4).unwrap();
 
                     info!("Handshake completed. prk_out = {:X}", i_prk_out);
                 }

--- a/examples/lakers-nrf52840/src/bin/initiator.rs
+++ b/examples/lakers-nrf52840/src/bin/initiator.rs
@@ -97,7 +97,7 @@ async fn main(spawner: Spawner) {
             let initiator = initiator.verify_message_2(valid_cred_r).unwrap();
 
             let (mut initiator, message_3, i_prk_out) = initiator
-                .prepare_message_3(CredentialTransfer::ByReference, &None)
+                .prepare_message_3(CredentialTransfer::ByReference, &EadItems::new())
                 .unwrap();
             let pckt_3 =
                 common::Packet::new_from_slice(message_3.as_slice(), Some(c_r.as_slice()[0]))

--- a/examples/lakers-nrf52840/src/bin/responder.rs
+++ b/examples/lakers-nrf52840/src/bin/responder.rs
@@ -86,7 +86,7 @@ async fn main(spawner: Spawner) {
             c_r = Some(generate_connection_identifier_cbor(
                 &mut lakers_crypto::default_crypto(),
             ));
-            let ead_2 = None;
+            let ead_2 = EadItems::new();
 
             let (responder, message_2) = responder
                 .prepare_message_2(CredentialTransfer::ByReference, c_r, &ead_2)
@@ -129,7 +129,7 @@ async fn main(spawner: Spawner) {
                         };
 
                         info!("Prepare message_4");
-                        let ead_4 = None;
+                        let ead_4 = EadItems::new();
                         let (responder, message_4) = responder.prepare_message_4(&ead_4).unwrap();
 
                         info!("Send message_4");

--- a/examples/lakers-nrf52840/src/bin/responder.rs
+++ b/examples/lakers-nrf52840/src/bin/responder.rs
@@ -1,7 +1,6 @@
 #![no_std]
 #![no_main]
 
-use common::{Packet, PacketError, ADV_ADDRESS, ADV_CRC_INIT, CRC_POLY, FREQ, MAX_PDU};
 use defmt::info;
 use defmt::unwrap;
 use embassy_executor::Spawner;
@@ -11,6 +10,9 @@ use embassy_nrf::radio::ble::Radio;
 use embassy_nrf::radio::TxPower;
 use embassy_nrf::{bind_interrupts, peripherals, radio};
 use embassy_time::{Duration, Timer};
+use lakers_nrf52840::{
+    self, Packet, PacketError, ADV_ADDRESS, ADV_CRC_INIT, CRC_POLY, FREQ, MAX_PDU,
+};
 use {defmt_rtt as _, panic_probe as _};
 
 use lakers::*;
@@ -27,8 +29,6 @@ static HEAP: Heap = Heap::empty();
 extern "C" {
     pub fn mbedtls_memory_buffer_alloc_init(buf: *mut c_char, len: usize);
 }
-
-mod common;
 
 bind_interrupts!(struct Irqs {
     RADIO => radio::InterruptHandler<peripherals::RADIO>;
@@ -65,16 +65,16 @@ async fn main(spawner: Spawner) {
     loop {
         let mut buffer: [u8; MAX_PDU] = [0x00u8; MAX_PDU];
         let mut c_r: Option<ConnId> = None;
-        let pckt = common::receive_and_filter(&mut radio, Some(0xf5)) // filter all incoming packets waiting for CBOR TRUE (0xf5)
+        let pckt = lakers_nrf52840::receive_and_filter(&mut radio, Some(0xf5)) // filter all incoming packets waiting for CBOR TRUE (0xf5)
             .await
             .unwrap();
 
         info!("Received message_1");
 
-        let cred_r = Credential::parse_ccs(common::CRED_R.try_into().unwrap()).unwrap();
+        let cred_r = Credential::parse_ccs(lakers_nrf52840::CRED_R.try_into().unwrap()).unwrap();
         let responder = EdhocResponder::new(
             lakers_crypto::default_crypto(),
-            common::R.try_into().unwrap(),
+            lakers_nrf52840::R.try_into().unwrap(),
             cred_r,
         );
 
@@ -93,7 +93,7 @@ async fn main(spawner: Spawner) {
                 .unwrap();
 
             // prepend 0xf5 also to message_2 in order to allow the Initiator filter out from other BLE packets
-            let message_3 = common::transmit_and_wait_response(
+            let message_3 = lakers_nrf52840::transmit_and_wait_response(
                 &mut radio,
                 Packet::new_from_slice(message_2.as_slice(), Some(0xf5)).expect("wrong length"),
                 Some(c_r.unwrap().as_slice()[0]),
@@ -119,7 +119,8 @@ async fn main(spawner: Spawner) {
                             continue;
                         };
                         let cred_i: Credential =
-                            Credential::parse_ccs(common::CRED_I.try_into().unwrap()).unwrap();
+                            Credential::parse_ccs(lakers_nrf52840::CRED_I.try_into().unwrap())
+                                .unwrap();
                         let valid_cred_i =
                             credential_check_or_fetch(Some(cred_i), id_cred_i).unwrap();
                         let Ok((responder, r_prk_out)) = responder.verify_message_3(valid_cred_i)
@@ -133,9 +134,9 @@ async fn main(spawner: Spawner) {
                         let (responder, message_4) = responder.prepare_message_4(&ead_4).unwrap();
 
                         info!("Send message_4");
-                        common::transmit_without_response(
+                        lakers_nrf52840::transmit_without_response(
                             &mut radio,
-                            common::Packet::new_from_slice(
+                            lakers_nrf52840::Packet::new_from_slice(
                                 message_4.as_slice(),
                                 Some(c_r.unwrap().as_slice()[0]),
                             )

--- a/examples/lakers-nrf52840/src/bin/responder.rs
+++ b/examples/lakers-nrf52840/src/bin/responder.rs
@@ -2,17 +2,12 @@
 #![no_main]
 
 use defmt::info;
-use defmt::unwrap;
 use embassy_executor::Spawner;
-use embassy_nrf::gpio::{Level, Output, OutputDrive};
 use embassy_nrf::radio::ble::Mode;
 use embassy_nrf::radio::ble::Radio;
 use embassy_nrf::radio::TxPower;
 use embassy_nrf::{bind_interrupts, peripherals, radio};
-use embassy_time::{Duration, Timer};
-use lakers_nrf52840::{
-    self, Packet, PacketError, ADV_ADDRESS, ADV_CRC_INIT, CRC_POLY, FREQ, MAX_PDU,
-};
+use lakers_nrf52840::{self, Packet, PacketError, ADV_ADDRESS, ADV_CRC_INIT, CRC_POLY, FREQ};
 use {defmt_rtt as _, panic_probe as _};
 
 use lakers::*;
@@ -35,7 +30,7 @@ bind_interrupts!(struct Irqs {
 });
 
 #[embassy_executor::main]
-async fn main(spawner: Spawner) {
+async fn main(_spawner: Spawner) {
     let mut config = embassy_nrf::config::Config::default();
     config.hfclk_source = embassy_nrf::config::HfclkSource::ExternalXtal;
     let peripherals: embassy_nrf::Peripherals = embassy_nrf::init(config);
@@ -63,8 +58,6 @@ async fn main(spawner: Spawner) {
     info!("Responder started, will wait for messages");
 
     loop {
-        let mut buffer: [u8; MAX_PDU] = [0x00u8; MAX_PDU];
-        let mut c_r: Option<ConnId> = None;
         let pckt = lakers_nrf52840::receive_and_filter(&mut radio, Some(0xf5)) // filter all incoming packets waiting for CBOR TRUE (0xf5)
             .await
             .unwrap();
@@ -82,8 +75,8 @@ async fn main(spawner: Spawner) {
 
         let result = responder.process_message_1(&message_1);
 
-        if let Ok((responder, _c_i, ead_1)) = result {
-            c_r = Some(generate_connection_identifier_cbor(
+        if let Ok((responder, _c_i, _ead_1)) = result {
+            let c_r = Some(generate_connection_identifier_cbor(
                 &mut lakers_crypto::default_crypto(),
             ));
             let ead_2 = EadItems::new();
@@ -131,7 +124,7 @@ async fn main(spawner: Spawner) {
 
                         info!("Prepare message_4");
                         let ead_4 = EadItems::new();
-                        let (responder, message_4) = responder.prepare_message_4(&ead_4).unwrap();
+                        let (_responder, message_4) = responder.prepare_message_4(&ead_4).unwrap();
 
                         info!("Send message_4");
                         lakers_nrf52840::transmit_without_response(
@@ -142,7 +135,8 @@ async fn main(spawner: Spawner) {
                             )
                             .unwrap(),
                         )
-                        .await;
+                        .await
+                        .unwrap();
 
                         info!("Handshake completed. prk_out = {:X}", r_prk_out);
                     } else {

--- a/examples/lakers-nrf52840/src/lib.rs
+++ b/examples/lakers-nrf52840/src/lib.rs
@@ -1,14 +1,8 @@
 #![no_std]
 
 use embassy_nrf::radio::ble::Radio;
-use embassy_nrf::saadc::Time;
-use embassy_nrf::{peripherals, radio};
-use embassy_time::Duration;
 use embassy_time::TimeoutError;
-use embassy_time::WithTimeout;
 use hexlit::hex;
-
-use defmt::info;
 
 pub const MAX_PDU: usize = 258;
 pub const FREQ: u32 = 2408;
@@ -75,16 +69,11 @@ impl Packet {
     }
 
     pub fn as_bytes(&mut self) -> &[u8] {
-        let mut offset = 0;
-        let mut len: usize = 0;
-
-        if let Some(header) = self.pdu_header {
-            offset = 3;
-            len = self.len + 1;
+        let (offset, len) = if self.pdu_header.is_some() {
+            (3, self.len + 1)
         } else {
-            offset = 2;
-            len = self.len;
-        }
+            (2, self.len)
+        };
         self.pdu.copy_within(..self.len, offset);
         self.pdu[0] = 0x00;
         self.pdu[1] = len as u8;
@@ -113,16 +102,14 @@ impl TryInto<Packet> for &[u8] {
 }
 
 impl From<TimeoutError> for PacketError {
-    fn from(error: TimeoutError) -> Self {
+    fn from(_error: TimeoutError) -> Self {
         PacketError::TimeoutError
     }
 }
 
 impl From<embassy_nrf::radio::Error> for PacketError {
-    fn from(error: embassy_nrf::radio::Error) -> Self {
-        match error {
-            _ => PacketError::RadioError,
-        }
+    fn from(_error: embassy_nrf::radio::Error) -> Self {
+        PacketError::RadioError
     }
 }
 
@@ -155,9 +142,6 @@ pub async fn transmit_and_wait_response(
     mut packet: Packet,
     filter: Option<u8>,
 ) -> Result<Packet, PacketError> {
-    let mut rcvd_packet: Packet = Default::default();
-    let mut buffer: [u8; MAX_PDU] = [0x00u8; MAX_PDU];
-
     radio.transmit(packet.as_bytes()).await?;
     let resp = receive_and_filter(radio, filter).await?;
 
@@ -170,11 +154,4 @@ pub async fn transmit_without_response(
 ) -> Result<(), PacketError> {
     radio.transmit(packet.as_bytes()).await?;
     Ok(())
-}
-
-use core::ffi::{c_char, c_void};
-#[no_mangle]
-pub extern "C" fn strstr(cs: *const c_char, ct: *const c_char) -> *mut c_char {
-    panic!("strstr handler!");
-    core::ptr::null_mut()
 }

--- a/examples/lakers-nrf52840/src/lib.rs
+++ b/examples/lakers-nrf52840/src/lib.rs
@@ -1,3 +1,5 @@
+#![no_std]
+
 use embassy_nrf::radio::ble::Radio;
 use embassy_nrf::saadc::Time;
 use embassy_nrf::{peripherals, radio};


### PR DESCRIPTION
I was writting examples for the STM32 and nRF54 (I am experimenting integrating with `embedded-cal`). So I used nRF52840 as an example.

But seems like this example is outdated, so this PR is a work after me to update the API usage and remove all warnings.

Tested on 2 nRF52840-DK