### PR TITLE
doc: Describe lakers-crypto as not being a go-to crate for applications

### DIFF
--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition = "2021"
 authors = ["Mališa Vučinić <malisa.vucinic@inria.fr>"]
 license.workspace = true
-description = "EDHOC crypto library dispatch crate"
+description = "EDHOC crypto library dispatch crate for development and testing"
 repository.workspace = true
 readme.workspace = true
 

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -1,9 +1,8 @@
 //! Cryptography dispatch for the lakers crate
 //!
-//! This crate is used by lakers to decide which cryptographic back-end to use. Its presence
-//! avoids the need for all lakers types to be generic over a back-end, which would then be
-//! provided by the user at initialization time. On the long run, its type may turn into a
-//! default associated type.
+//! This crate is used by lakers examples and demos to decide which cryptographic back-end to use.
+//! Production applications are encouraged to pick a back-end directly and pass that into their
+//! application over selecting a [`default_crypto()`], as defaults are not stable.
 #![cfg_attr(not(test), no_std)]
 
 /// Convenience re-export


### PR DESCRIPTION
Reviewing https://github.com/lake-rs/lakers/pull/426 I was confused by the dependencies being added – the ones in there make sense for testing, but applications should not rely, actually should long not have relied on lakers-crypto but use their own judgement.