### PR TITLE
Allow EAD items to have values > 255

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -48,13 +48,14 @@ jobs:
       matrix:
         crypto_backend: [lakers-crypto/psa, lakers-crypto/rustcrypto]
         ead: [ead-none, ead-authz]
+        buffers: [default-buffers, large-buffers]
 
     steps:
     - name: Checkout repo
       uses: actions/checkout@v4
 
     - name: Run unit tests with feature matrix # note that we only add `--package lakers-ead-authz` when testing with that config
-      run: RUST_BACKTRACE=1 cargo test -p lakers -p lakers-crypto -p lakers-shared ${{ matrix.ead == 'ead-authz' && '-p lakers-ead-authz' || '' }}  --no-default-features --features="${{ matrix.crypto_backend }}, test-${{ matrix.ead }}" --no-fail-fast -- --test-threads 1
+      run: RUST_BACKTRACE=1 cargo test -p lakers -p lakers-crypto -p lakers-shared ${{ matrix.ead == 'ead-authz' && '-p lakers-ead-authz' || '' }}  --no-default-features --features="${{ matrix.crypto_backend }}, test-${{ matrix.ead }}${{ matrix.buffers == 'large-buffers' && ', lakers-shared/large_buffers' || '' }}" --no-fail-fast -- --test-threads 1
 
 
   build-edhoc-package:

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -97,6 +97,7 @@ pub const MAX_BUFFER_LEN: usize = if cfg!(feature = "max_buffer_len_1024") {
     256 + 64
 };
 pub const CBOR_BYTE_STRING: u8 = 0x58u8;
+pub const CBOR_BYTE_STRING_2BYTE_LEN: u8 = 0x59u8;
 pub const CBOR_TEXT_STRING: u8 = 0x78u8;
 pub const CBOR_UINT_1BYTE: u8 = 0x18u8;
 pub const CBOR_NEG_INT_1BYTE_START: u8 = 0x20u8;
@@ -115,7 +116,7 @@ pub const CBOR_MAJOR_ARRAY_MAX: u8 = 0x97u8;
 pub const CBOR_MAJOR_MAP: u8 = 0xA0;
 pub const MAX_INFO_LEN: usize = 2 + SHA256_DIGEST_LEN + // 32-byte digest as bstr
 				            1 + MAX_KDF_LABEL_LEN +     // label <24 bytes as tstr
-						    1 + MAX_KDF_CONTEXT_LEN +   // context <24 bytes as bstr
+						    3 + MAX_KDF_CONTEXT_LEN +   // context as bstr, up to a 2-byte length header
 						    1; // length as u8
 
 pub const KCCS_LABEL: u8 = 14;
@@ -943,9 +944,13 @@ mod helpers {
         if context.len() < 24 {
             info.push(context.len() as u8 | CBOR_MAJOR_BYTE_STRING)
                 .unwrap();
-        } else {
+        } else if context.len() <= u8::MAX as usize {
             info.push(CBOR_BYTE_STRING).unwrap();
             info.push(context.len() as u8).unwrap();
+        } else {
+            info.push(CBOR_BYTE_STRING_2BYTE_LEN).unwrap();
+            info.extend_from_slice(&(context.len() as u16).to_be_bytes())
+                .unwrap();
         };
         info.extend_from_slice(context).unwrap();
 
@@ -1670,5 +1675,31 @@ mod test_ead_items {
             .iter()
             .map(|i| (i.label(), i.is_critical(), Vec::from(i.value.as_slice())))
             .collect::<Vec<_>>()
+    }
+}
+
+#[cfg(test)]
+mod test_encode_info {
+    use super::*;
+
+    #[test]
+    fn context_length_header_is_well_formed() {
+        let info = encode_info(2, &[0xaa; 10], 32);
+        assert_eq!(&info.as_slice()[..2], &[0x02, 0x4a]);
+
+        let info = encode_info(2, &[0xaa; 200], 32);
+        assert_eq!(&info.as_slice()[..3], &[0x02, 0x58, 200]);
+
+        let info = encode_info(2, &[0xaa; 256], 32);
+        assert_eq!(&info.as_slice()[..4], &[0x02, 0x59, 0x01, 0x00]);
+    }
+
+    #[test]
+    fn long_context_is_encoded_in_full() {
+        let context = [0xaa; 256];
+        let info = encode_info(2, &context, 32);
+        assert_eq!(info.len(), 1 + 3 + context.len() + 2);
+        assert_eq!(&info.as_slice()[4..4 + context.len()], &context[..]);
+        assert_eq!(&info.as_slice()[info.len() - 2..], &[0x18, 0x20]);
     }
 }

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -682,7 +682,7 @@ impl EADItem {
                 value.push(head).unwrap();
                 value.push(value_bytes.len() as u8).unwrap();
             } else if value_bytes.len() <= u16::MAX.into() {
-                head |= 24;
+                head |= 25;
                 value.push(head).unwrap();
                 value
                     .extend_from_slice(&(value_bytes.len() as u16).to_be_bytes())

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -1496,12 +1496,20 @@ mod cbor_decoder {
             }
         }
 
-        /// Decode a `u8` value into usize.
+        /// Decode a CBOR argument from the given additional-information value, reading any following argument bytes.
         pub fn as_usize(&mut self, b: u8) -> Result<usize, CBORError> {
             if (0..=0x17).contains(&b) {
                 Ok(usize::from(b))
             } else if 0x18 == b {
                 self.read().map(usize::from)
+            } else if 0x19 == b {
+                let high = self.read()?;
+                let low = self.read()?;
+                let value = usize::from(u16::from_be_bytes([high, low]));
+                if value <= u8::MAX as usize {
+                    return Err(CBORError::DecodingError); // deterministic CBOR
+                }
+                Ok(value)
             } else {
                 Err(CBORError::DecodingError)
             }
@@ -1612,6 +1620,28 @@ mod test_cbor_decoder {
 
         assert_eq!(input, decoder.any_as_encoded().unwrap());
         assert!(decoder.finished())
+    }
+
+    #[test]
+    fn test_cbor_decoder_long_bytes() {
+        let mut input = [0xab; 3 + 300]; // header + 300
+        input[..3].copy_from_slice(&[0x59, 0x01, 0x2c]); // 0x012c = 300
+
+        let mut decoder = CBORDecoder::new(&input);
+        let bytes = decoder.bytes().unwrap();
+        assert_eq!(bytes.len(), 300);
+        assert_eq!(bytes, &[0xab; 300][..]);
+        assert!(decoder.finished());
+    }
+
+    #[test]
+    fn test_cbor_decoder_rejects_non_minimal_length() {
+        // 0x0010 = 16, which must be encoded as the single byte 0x50
+        let mut input = [0xab; 3 + 16];
+        input[..3].copy_from_slice(&[0x59, 0x00, 0x10]);
+
+        let mut decoder = CBORDecoder::new(&input);
+        assert!(decoder.bytes().is_err());
     }
 }
 


### PR DESCRIPTION
Continuing from #429 

EAD item only worked with values of > 256 bytes.

This PR corrects this and adds some regression tests