### PR TITLE
Add EDHOC resumption PSK derivation

### DIFF
--- a/examples/lakers-no_std/src/main.rs
+++ b/examples/lakers-no_std/src/main.rs
@@ -206,8 +206,10 @@ fn main() -> ! {
         let valid_cred_i = credential_check_or_fetch(Some(cred_i), id_cred_i).unwrap();
         let (responder, r_prk_out) = responder.verify_message_3(valid_cred_i).unwrap();
 
-        let mut initiator = initiator.completed_without_message_4().unwrap();
-        let mut responder = responder.completed_without_message_4().unwrap();
+        // message_4 is mandatory in the PSK method: it is the Responder's only proof of
+        // possession of the PSK, so neither peer may complete the exchange without it.
+        let (mut responder, message_4) = responder.prepare_message_4(&EadItems::new()).unwrap();
+        let (mut initiator, _ead_4) = initiator.process_message_4(&message_4).unwrap();
 
         // check that prk_out is equal at initiator and responder side
         assert_eq!(i_prk_out, r_prk_out);

--- a/lakers-c/src/initiator.rs
+++ b/lakers-c/src/initiator.rs
@@ -319,7 +319,6 @@ mod tests {
 
     fn make_ffi_initiator() -> EdhocInitiator {
         EdhocInitiator {
-            method: EDHOCMethod::StatStat,
             start: InitiatorStart {
                 suites_i: Default::default(),
                 method: EDHOCMethod::StatStat,
@@ -338,6 +337,7 @@ mod tests {
                 th_4: Default::default(),
                 prk_out: Default::default(),
                 prk_exporter: Default::default(),
+                method: EDHOCMethod::StatStat,
             },
             cred_i: core::ptr::null_mut(),
             completed: Completed {
@@ -396,14 +396,13 @@ mod tests {
 
     #[test]
     // initiator_new_stores_requested_method creates an FFI initiator struct,
-    // calls initiator_new, and checks that both initiator.method and
-    // initiator.start.method were set to the requested method.
+    // calls initiator_new, and checks that the requested method was stored in
+    // initiator.start, which is the only field initiator_new writes.
     fn initiator_new_stores_requested_method() {
         let mut initiator = make_ffi_initiator();
         unsafe {
             assert_eq!(initiator_new(&mut initiator, EDHOCMethod::PSK), 0);
         }
-        assert!(matches!(initiator.method, EDHOCMethod::PSK));
         assert!(matches!(initiator.start.method, EDHOCMethod::PSK));
     }
 

--- a/lib/src/edhoc.rs
+++ b/lib/src/edhoc.rs
@@ -78,6 +78,38 @@ pub fn edhoc_key_update(
     state.prk_out
 }
 
+// TODO: complete the derivation
+pub fn derive_resumption_psk(
+    state: &Completed,
+    crypto: &mut impl CryptoTrait,
+) -> Result<ResumptionPsk, EDHOCError> {
+    let mut rpsk: BytesResumptionPsk = Default::default();
+    edhoc_kdf(
+        crypto,
+        &state.prk_exporter,
+        RESUMPTION_PSK_LABEL,
+        &[],
+        &mut rpsk,
+    );
+
+    let mut kid = [0; RESUMPTION_PSK_KID_LEN];
+    edhoc_kdf(
+        crypto,
+        &state.prk_exporter,
+        RESUMPTION_PSK_KID_LABEL,
+        &[],
+        &mut kid,
+    );
+
+    // then build id_cred_psk
+    let rid_cred_psk = IdCred::from_kid(kid.as_slice())?;
+
+    Ok(ResumptionPsk {
+        rpsk,
+        kid,
+        rid_cred_psk,
+    })
+}
 pub fn r_process_message_1(
     state: &ResponderStart,
     crypto: &mut impl CryptoTrait,

--- a/lib/src/edhoc.rs
+++ b/lib/src/edhoc.rs
@@ -1327,6 +1327,13 @@ mod tests {
     // === PRK_exporter ===
     const PRK_EXPORTER_PSK_TV: BytesHashLen =
         hex!("2fcd08c0c01077c6d6486b9f9b677020e8d68f04bcdcce715dd277ed25931bef");
+    // === Resumption PSK, exported from PRK_exporter with RESUMPTION_PSK_LABEL ===
+    const R_PSK_TV: BytesResumptionPsk =
+        hex!("e87f51f53e3dd57195fe5ce5f3ed038abcc5ca6bf00f3a1c4a9bfc614ae87a0a");
+    // === kid of the resumption PSK, exported with RESUMPTION_PSK_KID_LABEL ===
+    const R_KID_TV: [u8; RESUMPTION_PSK_KID_LEN] = hex!("f38c");
+    // === ID_CRED_PSK of the resumption PSK: {4: h'F38C'} ===
+    const R_ID_CRED_PSK_TV: [u8; 5] = hex!("a10442f38c");
     const _ENC_STRUCURE_MESSAGE_3: EdhocBuffer<MAX_BUFFER_LEN> =
         EdhocBuffer::new_from_array(&hex!(
         "8368456e637279707430405871105820386a9d052b255992eee5ffb594347d327418a2ea5183486c0c9e204
@@ -2005,10 +2012,6 @@ mod tests {
         assert_eq!(prk_4e3m, PRK_4E3M_PSK_TV);
     }
 
-    // fn test_compute_prk_4e3m_rpsk() {
-    //     let prk_4e3m = compute_prk_4e3m_psk(&mut default_crypto(), &SALT_4E3M_PSK_TV, &R_PSK_TV);
-    //     assert_eq!(prk_4e3m, PRK_4E3M_R_PSK_TV);
-    // }
     #[test]
     fn test_symmetric_32_bytes() {
         let psk_32 = BufferPsk::new_from_slice(&[0xAB; 32]).unwrap();
@@ -2195,6 +2198,19 @@ mod tests {
         let prk_exporter = edhoc_kdf_owned(&mut default_crypto(), &PRK_OUT_PSK_TV, 10u8, &[]);
 
         assert_eq!(prk_exporter, PRK_EXPORTER_PSK_TV);
+    }
+
+    #[test]
+    fn test_derive_resumption_psk() {
+        let completed = Completed {
+            prk_out: PRK_OUT_PSK_TV,
+            prk_exporter: PRK_EXPORTER_PSK_TV,
+        };
+
+        let resumption = derive_resumption_psk(&completed, &mut default_crypto()).unwrap();
+
+        assert_eq!(resumption.rpsk.as_slice(), &R_PSK_TV);
+        assert_eq!(resumption.kid, R_KID_TV);
     }
 
     #[test]

--- a/lib/src/edhoc.rs
+++ b/lib/src/edhoc.rs
@@ -271,14 +271,25 @@ pub fn r_verify_message_3(
 ) -> Result<(ProcessedM3, BytesHashLen), EDHOCError> {
     let salt_4e3m = compute_salt_4e3m(crypto, &state.prk_3e2m, &state.th_3);
 
-    let verified = match &state.method_specifics {
-        ProcessingM3MethodSpecifics::StatStat { mac_3, id_cred_i } => {
-            r_verify_message_3_statstat(state, crypto, valid_cred_i, *mac_3, id_cred_i, &salt_4e3m)?
-        }
+    let (verified, method) = match &state.method_specifics {
+        ProcessingM3MethodSpecifics::StatStat { mac_3, id_cred_i } => (
+            r_verify_message_3_statstat(
+                state,
+                crypto,
+                valid_cred_i,
+                *mac_3,
+                id_cred_i,
+                &salt_4e3m,
+            )?,
+            EDHOCMethod::StatStat,
+        ),
         ProcessingM3MethodSpecifics::Psk {
             id_cred_psk,
             cred_r,
-        } => r_verify_message_3_psk(state, crypto, valid_cred_i, id_cred_psk, cred_r, &salt_4e3m)?,
+        } => (
+            r_verify_message_3_psk(state, crypto, valid_cred_i, id_cred_psk, cred_r, &salt_4e3m)?,
+            EDHOCMethod::PSK,
+        ),
     };
 
     let mut prk_out: BytesHashLen = Default::default();
@@ -299,6 +310,7 @@ pub fn r_verify_message_3(
             th_4: verified.th_4,
             prk_out,
             prk_exporter,
+            method,
         },
         prk_out,
     ))
@@ -322,11 +334,24 @@ pub fn r_prepare_message_4(
     ))
 }
 
+/// Completes the exchange on the Responder side without sending message_4.
+///
+/// This is only allowed for method StatStat, where the Responder is authenticated to the Initiator
+/// by Signature_or_MAC_2 in message_2, so key confirmation may instead be provided by a subsequent
+/// OSCORE request.
+///
+/// In the PSK method there is no authenticator in message_2: the PSK enters the key schedule only
+/// at PRK_4e3m, and message_4 is the Responder's sole proof of possession of it. Skipping message_4
+/// would therefore leave the Responder unauthenticated, so PSK is rejected here.
 pub fn r_complete_without_message_4(state: &ProcessedM3) -> Result<Completed, EDHOCError> {
-    Ok(Completed {
-        prk_out: state.prk_out,
-        prk_exporter: state.prk_exporter,
-    })
+    match state.method {
+        EDHOCMethod::PSK => Err(EDHOCError::UnsupportedMethod),
+        EDHOCMethod::StatStat => Ok(Completed {
+            prk_out: state.prk_out,
+            prk_exporter: state.prk_exporter,
+        }),
+        _ => Err(EDHOCError::UnsupportedMethod),
+    }
 }
 
 pub fn i_prepare_message_1(
@@ -420,13 +445,15 @@ pub fn i_prepare_message_3(
     cred_transfer: CredentialTransfer,
     ead_3: &EadItems,
 ) -> Result<(WaitM4, BufferMessage3, BytesHashLen), EDHOCError> {
-    let prepared = match state.method_specifics {
-        ProcessedM2MethodSpecifics::StatStat { .. } => {
-            i_prepare_message_3_statstat(state, crypto, cred_i, cred_transfer, ead_3)?
-        }
-        ProcessedM2MethodSpecifics::Psk { .. } => {
-            i_prepare_message_3_psk(state, crypto, cred_i, cred_transfer, ead_3)?
-        }
+    let (prepared, method) = match state.method_specifics {
+        ProcessedM2MethodSpecifics::StatStat { .. } => (
+            i_prepare_message_3_statstat(state, crypto, cred_i, cred_transfer, ead_3)?,
+            EDHOCMethod::StatStat,
+        ),
+        ProcessedM2MethodSpecifics::Psk { .. } => (
+            i_prepare_message_3_psk(state, crypto, cred_i, cred_transfer, ead_3)?,
+            EDHOCMethod::PSK,
+        ),
     };
 
     let mut prk_out: BytesHashLen = Default::default();
@@ -441,6 +468,7 @@ pub fn i_prepare_message_3(
             th_4: prepared.th_4,
             prk_out,
             prk_exporter,
+            method,
         },
         prepared.message_3,
         prk_out,
@@ -468,11 +496,24 @@ pub fn i_process_message_4(
     }
 }
 
+/// Completes the exchange on the Initiator side without processing message_4.
+///
+/// This is only allowed for method StatStat, where the Responder was already authenticated by
+/// Signature_or_MAC_2 in message_2.
+///
+/// In the PSK method message_4 is the only point at which the Initiator learns that its peer knows
+/// the PSK. Note that PRK_out and PRK_exporter are fully determined before message_4 arrives, so
+/// skipping it would silently yield usable-looking keys (and a usable-looking resumption PSK) for a
+/// peer that was never authenticated. PSK is therefore rejected here.
 pub fn i_complete_without_message_4(state: &WaitM4) -> Result<Completed, EDHOCError> {
-    Ok(Completed {
-        prk_out: state.prk_out,
-        prk_exporter: state.prk_exporter,
-    })
+    match state.method {
+        EDHOCMethod::PSK => Err(EDHOCError::UnsupportedMethod),
+        EDHOCMethod::StatStat => Ok(Completed {
+            prk_out: state.prk_out,
+            prk_exporter: state.prk_exporter,
+        }),
+        _ => Err(EDHOCError::UnsupportedMethod),
+    }
 }
 
 fn encode_message_1(

--- a/lib/src/edhoc.rs
+++ b/lib/src/edhoc.rs
@@ -1332,7 +1332,7 @@ mod tests {
         hex!("e87f51f53e3dd57195fe5ce5f3ed038abcc5ca6bf00f3a1c4a9bfc614ae87a0a");
     // === kid of the resumption PSK, exported with RESUMPTION_PSK_KID_LABEL ===
     const R_KID_TV: [u8; RESUMPTION_PSK_KID_LEN] = hex!("f38c");
-    // === ID_CRED_PSK of the resumption PSK: {4: h'F38C'} ===
+    // === ID_CRED_PSK of the resumption PSK, full value: {4: h'F38C'} ===
     const R_ID_CRED_PSK_TV: [u8; 5] = hex!("a10442f38c");
     const _ENC_STRUCURE_MESSAGE_3: EdhocBuffer<MAX_BUFFER_LEN> =
         EdhocBuffer::new_from_array(&hex!(
@@ -2211,6 +2211,10 @@ mod tests {
 
         assert_eq!(resumption.rpsk.as_slice(), &R_PSK_TV);
         assert_eq!(resumption.kid, R_KID_TV);
+        // The kid is wrapped as ID_CRED_PSK = {4: h'F38C'}, a reference to a credential rather
+        // than a credential by value.
+        assert!(resumption.rid_cred_psk.reference_only());
+        assert_eq!(resumption.rid_cred_psk.as_full_value(), &R_ID_CRED_PSK_TV);
     }
 
     #[test]

--- a/lib/src/edhoc.rs
+++ b/lib/src/edhoc.rs
@@ -83,14 +83,15 @@ pub fn derive_resumption_psk(
     state: &Completed,
     crypto: &mut impl CryptoTrait,
 ) -> Result<ResumptionPsk, EDHOCError> {
-    let mut rpsk: BytesResumptionPsk = Default::default();
+    let mut rpsk_bytes: BytesResumptionPsk = Default::default();
     edhoc_kdf(
         crypto,
         &state.prk_exporter,
         RESUMPTION_PSK_LABEL,
         &[],
-        &mut rpsk,
+        &mut rpsk_bytes,
     );
+    let rpsk = BufferPsk::new_from_slice(&rpsk_bytes).map_err(|_| EDHOCError::EncodingError)?;
 
     let mut kid = [0; RESUMPTION_PSK_KID_LEN];
     edhoc_kdf(

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -868,46 +868,6 @@ mod test {
 
         assert_eq!(i_oscore_secret, r_oscore_secret);
         assert_eq!(i_oscore_salt, r_oscore_salt);
-    }
-    #[cfg(feature = "test-ead-none")]
-    #[test]
-    fn test_resumption() {
-        let cred_i = Credential::parse_ccs_symmetric(CRED_I_PSK.try_into().unwrap()).unwrap();
-        let cred_r = Credential::parse_ccs_symmetric(CRED_R_PSK.try_into().unwrap()).unwrap();
-
-        let initiator =
-            EdhocInitiator::new(default_crypto(), EDHOCMethod::PSK, EDHOCSuite::CipherSuite2);
-
-        let responder =
-            EdhocResponder::new(default_crypto(), ResponderIdentity::Psk, cred_r.clone());
-
-        let (initiator, message_1) = initiator.prepare_message_1(None, &EadItems::new()).unwrap();
-
-        let (responder, _c_i, _ead_1) = responder.process_message_1(&message_1).unwrap();
-        let (responder, message_2) = responder
-            .prepare_message_2(CredentialTransfer::ByReference, None, &EadItems::new())
-            .unwrap();
-
-        let (mut initiator, _c_r, _ead_2) = initiator.parse_message_2(&message_2).unwrap();
-        initiator
-            .set_identity(InitiatorIdentity::Psk, cred_i.clone())
-            .unwrap();
-        let initiator = initiator.verify_message_2(Some(cred_r)).unwrap();
-
-        let (initiator, message_3, _i_prk_out) = initiator
-            .prepare_message_3(CredentialTransfer::ByReference, &EadItems::new())
-            .unwrap();
-
-        let (responder, id_cred_i, _ead_3) = responder
-            .parse_message_3_with_credential_lookup(&message_3, |id| {
-                credential_check_or_fetch(Some(cred_i.clone()), id.clone())
-            })
-            .unwrap();
-        assert!(id_cred_i.reference_only());
-        let (responder, _r_prk_out) = responder.verify_message_3(cred_i.clone()).unwrap();
-
-        let (mut responder, message_4) = responder.prepare_message_4(&EadItems::new()).unwrap();
-        let (mut initiator, _ead_4) = initiator.process_message_4(&message_4).unwrap();
 
         let i_resumption = initiator.derive_resumption_psk().unwrap();
         let r_resumption = responder.derive_resumption_psk().unwrap();

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -309,6 +309,10 @@ impl<Crypto: CryptoTrait> EdhocResponderDone<Crypto> {
     pub fn edhoc_key_update(&mut self, context: &[u8]) -> [u8; SHA256_DIGEST_LEN] {
         edhoc_key_update(&mut self.state, &mut self.crypto, context)
     }
+
+    pub fn derive_resumption_psk(&mut self) -> Result<ResumptionPsk, EDHOCError> {
+        derive_resumption_psk(&mut self.state, &mut self.crypto)
+    }
 }
 
 impl<'a, Crypto: CryptoTrait> EdhocInitiator<Crypto> {
@@ -512,6 +516,10 @@ impl<Crypto: CryptoTrait> EdhocInitiatorDone<Crypto> {
 
     pub fn edhoc_key_update(&mut self, context: &[u8]) -> [u8; SHA256_DIGEST_LEN] {
         edhoc_key_update(&mut self.state, &mut self.crypto, context)
+    }
+
+    pub fn derive_resumption_psk(&mut self) -> Result<ResumptionPsk, EDHOCError> {
+        derive_resumption_psk(&mut self.state, &mut self.crypto)
     }
 }
 
@@ -860,6 +868,72 @@ mod test {
 
         assert_eq!(i_oscore_secret, r_oscore_secret);
         assert_eq!(i_oscore_salt, r_oscore_salt);
+    }
+    #[cfg(feature = "test-ead-none")]
+    #[test]
+    fn test_resumption() {
+        let cred_i = Credential::parse_ccs_symmetric(CRED_I_PSK.try_into().unwrap()).unwrap();
+        let cred_r = Credential::parse_ccs_symmetric(CRED_R_PSK.try_into().unwrap()).unwrap();
+
+        let initiator =
+            EdhocInitiator::new(default_crypto(), EDHOCMethod::PSK, EDHOCSuite::CipherSuite2);
+
+        let responder =
+            EdhocResponder::new(default_crypto(), ResponderIdentity::Psk, cred_r.clone());
+
+        let (initiator, message_1) = initiator.prepare_message_1(None, &EadItems::new()).unwrap();
+
+        let (responder, _c_i, _ead_1) = responder.process_message_1(&message_1).unwrap();
+        let (responder, message_2) = responder
+            .prepare_message_2(CredentialTransfer::ByReference, None, &EadItems::new())
+            .unwrap();
+
+        let (mut initiator, _c_r, _ead_2) = initiator.parse_message_2(&message_2).unwrap();
+        initiator
+            .set_identity(InitiatorIdentity::Psk, cred_i.clone())
+            .unwrap();
+        let initiator = initiator.verify_message_2(Some(cred_r)).unwrap();
+
+        let (initiator, message_3, _i_prk_out) = initiator
+            .prepare_message_3(CredentialTransfer::ByReference, &EadItems::new())
+            .unwrap();
+
+        let (responder, id_cred_i, _ead_3) = responder
+            .parse_message_3_with_credential_lookup(&message_3, |id| {
+                credential_check_or_fetch(Some(cred_i.clone()), id.clone())
+            })
+            .unwrap();
+        assert!(id_cred_i.reference_only());
+        let (responder, _r_prk_out) = responder.verify_message_3(cred_i.clone()).unwrap();
+
+        let (mut responder, message_4) = responder.prepare_message_4(&EadItems::new()).unwrap();
+        let (mut initiator, _ead_4) = initiator.process_message_4(&message_4).unwrap();
+
+        let i_resumption = initiator.derive_resumption_psk().unwrap();
+        let r_resumption = responder.derive_resumption_psk().unwrap();
+
+        assert_eq!(i_resumption.rpsk, r_resumption.rpsk);
+        assert_eq!(i_resumption.kid, r_resumption.kid);
+        assert_eq!(
+            i_resumption.rid_cred_psk.as_full_value(),
+            r_resumption.rid_cred_psk.as_full_value()
+        );
+        assert_eq!(i_resumption.rpsk.len(), SHA256_DIGEST_LEN);
+        assert_eq!(i_resumption.kid.len(), RESUMPTION_PSK_KID_LEN);
+
+        assert_eq!(
+            &i_resumption.rid_cred_psk.as_full_value()[..3],
+            &[
+                CBOR_MAJOR_MAP + 1,
+                KID_LABEL,
+                CBOR_MAJOR_BYTE_STRING | RESUMPTION_PSK_KID_LEN as u8,
+            ],
+        );
+
+        assert_eq!(
+            &i_resumption.rid_cred_psk.as_full_value()[3..],
+            i_resumption.kid.as_slice(),
+        );
     }
 
     #[test]

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -497,10 +497,10 @@ impl<'a, Crypto: CryptoTrait> EdhocInitiatorWaitM4<Crypto> {
         }
     }
 
-    pub fn completed_without_message_4(self) -> Result<EdhocResponderDone<Crypto>, EDHOCError> {
+    pub fn completed_without_message_4(self) -> Result<EdhocInitiatorDone<Crypto>, EDHOCError> {
         trace!("Enter completed");
         match i_complete_without_message_4(&self.state) {
-            Ok(state) => Ok(EdhocResponderDone {
+            Ok(state) => Ok(EdhocInitiatorDone {
                 state,
                 crypto: self.crypto,
             }),
@@ -893,6 +893,59 @@ mod test {
         assert_eq!(
             &i_resumption.rid_cred_psk.as_full_value()[3..],
             i_resumption.kid.as_slice(),
+        );
+    }
+
+    /// message_4 is mandatory in the PSK method: it is the Responder's only proof of possession of
+    /// the PSK, so neither peer may reach a Completed state without it. See
+    /// [`i_complete_without_message_4`] and [`r_complete_without_message_4`].
+    #[cfg(feature = "test-ead-none")]
+    #[test]
+    fn test_psk_rejects_completing_without_message_4() {
+        let cred_i = Credential::parse_ccs_symmetric(CRED_I_PSK.try_into().unwrap()).unwrap();
+        let cred_r = Credential::parse_ccs_symmetric(CRED_R_PSK.try_into().unwrap()).unwrap();
+
+        let initiator =
+            EdhocInitiator::new(default_crypto(), EDHOCMethod::PSK, EDHOCSuite::CipherSuite2);
+        let responder =
+            EdhocResponder::new(default_crypto(), ResponderIdentity::Psk, cred_r.clone());
+
+        let (initiator, message_1) = initiator.prepare_message_1(None, &EadItems::new()).unwrap();
+
+        let (responder, _c_i, _ead_1) = responder.process_message_1(&message_1).unwrap();
+        let (responder, message_2) = responder
+            .prepare_message_2(CredentialTransfer::ByReference, None, &EadItems::new())
+            .unwrap();
+
+        let (mut initiator, _c_r, _ead_2) = initiator.parse_message_2(&message_2).unwrap();
+        initiator
+            .set_identity(InitiatorIdentity::Psk, cred_i.clone())
+            .unwrap();
+        let initiator = initiator.verify_message_2(Some(cred_r)).unwrap();
+
+        let (initiator, message_3, _i_prk_out) = initiator
+            .prepare_message_3(CredentialTransfer::ByReference, &EadItems::new())
+            .unwrap();
+
+        let (responder, _id_cred_i, _ead_3) = responder
+            .parse_message_3_with_credential_lookup(&message_3, |id| {
+                credential_check_or_fetch(Some(cred_i.clone()), id.clone())
+            })
+            .unwrap();
+        let (responder, _r_prk_out) = responder.verify_message_3(cred_i.clone()).unwrap();
+
+        // The Responder has authenticated the Initiator and already holds PRK_exporter, but it
+        // still owes the Initiator message_4.
+        assert_eq!(
+            responder.completed_without_message_4().unwrap_err(),
+            EDHOCError::UnsupportedMethod,
+        );
+
+        // The Initiator's PRK_out is fixed at this point too, so skipping message_4 would yield
+        // keys for a peer it never authenticated.
+        assert_eq!(
+            initiator.completed_without_message_4().unwrap_err(),
+            EDHOCError::UnsupportedMethod,
         );
     }
 

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -872,13 +872,13 @@ mod test {
         let i_resumption = initiator.derive_resumption_psk().unwrap();
         let r_resumption = responder.derive_resumption_psk().unwrap();
 
-        assert_eq!(i_resumption.rpsk, r_resumption.rpsk);
+        assert_eq!(i_resumption.rpsk.as_slice(), r_resumption.rpsk.as_slice());
         assert_eq!(i_resumption.kid, r_resumption.kid);
         assert_eq!(
             i_resumption.rid_cred_psk.as_full_value(),
             r_resumption.rid_cred_psk.as_full_value()
         );
-        assert_eq!(i_resumption.rpsk.len(), SHA256_DIGEST_LEN);
+        assert_eq!(i_resumption.rpsk.as_slice().len(), SHA256_DIGEST_LEN);
         assert_eq!(i_resumption.kid.len(), RESUMPTION_PSK_KID_LEN);
 
         assert_eq!(

--- a/shared/src/cred.rs
+++ b/shared/src/cred.rs
@@ -179,6 +179,29 @@ impl IdCred {
     fn bstr_representable_as_int(value: u8) -> bool {
         (0x0..=0x17).contains(&value) || (0x20..=0x37).contains(&value)
     }
+
+    pub fn from_kid(value: &[u8]) -> Result<Self, EDHOCError> {
+        let mut id_cred = IdCred::new();
+        if value.len() > 0 && value.len() <= 23 {
+            id_cred
+                .bytes
+                .extend_from_slice(&[
+                    CBOR_MAJOR_MAP + 1,
+                    KID_LABEL,
+                    CBOR_MAJOR_BYTE_STRING | value.len() as u8,
+                ])
+                .map_err(|_| EDHOCError::CredentialTooLongError)?;
+
+            id_cred
+                .bytes
+                .extend_from_slice(value)
+                .map_err(|_| EDHOCError::CredentialTooLongError)?;
+        } else {
+            return Err(EDHOCError::ParsingError);
+        }
+
+        Ok(id_cred)
+    }
 }
 
 /// A credential for use in EDHOC.

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -382,7 +382,7 @@ pub enum EDHOCMethod {
 }
 
 pub struct ResumptionPsk {
-    pub rpsk: BytesResumptionPsk,
+    pub rpsk: BufferPsk,
     pub kid: [u8; RESUMPTION_PSK_KID_LEN],
     pub rid_cred_psk: IdCred,
 }

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -624,6 +624,7 @@ pub struct ProcessedM3 {
     pub th_4: BytesHashLen,
     pub prk_out: BytesHashLen,
     pub prk_exporter: BytesHashLen,
+    pub method: EDHOCMethod, // Added to reject complete_without_message_4 for PSK
 }
 
 #[derive(Debug)]
@@ -633,6 +634,7 @@ pub struct WaitM4 {
     pub th_4: BytesHashLen,
     pub prk_out: BytesHashLen,
     pub prk_exporter: BytesHashLen,
+    pub method: EDHOCMethod, // Added to reject complete_without_message_4 for PSK
 }
 
 #[derive(Debug)]

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -128,8 +128,10 @@ pub const KCCS_LABEL: u8 = 14;
 pub const KCSS_LABEL: u8 = KCCS_LABEL;
 pub const KID_LABEL: u8 = 4;
 pub const RESUMPTION_PSK_KID_LEN: usize = 2;
-pub const RESUMPTION_PSK_LABEL: u8 = 15; // TODO : to be defined
-pub const RESUMPTION_PSK_KID_LABEL: u8 = 16; // TODO: to be defined
+/// EDHOC-Exporter label for the resumption PSK, applied to PRK_exporter.
+pub const RESUMPTION_PSK_LABEL: u8 = 2;
+/// EDHOC-Exporter label for the resumption PSK's `kid`, applied to PRK_exporter.
+pub const RESUMPTION_PSK_KID_LABEL: u8 = 3;
 pub const ENC_STRUCTURE_LEN: usize = 8 + 5 + SHA256_DIGEST_LEN; // 8 for ENCRYPT0
 pub const ENC_STRUCTURE_PSK_LEN: usize = 1 + 1 + 8 + 1 + EXTERNAL_AAD_PSK_LEN; //
 pub const EXTERNAL_AAD_PSK_LEN: usize = 1 + 1 + 2 + 32 + 2 + 38 + 2 + 38 + 1;

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -127,7 +127,9 @@ pub const KCCS_LABEL: u8 = 14;
 #[deprecated(note = "Typo for KCCS_LABEL")]
 pub const KCSS_LABEL: u8 = KCCS_LABEL;
 pub const KID_LABEL: u8 = 4;
-
+pub const RESUMPTION_PSK_KID_LEN: usize = 2;
+pub const RESUMPTION_PSK_LABEL: u8 = 15; // TODO : to be defined
+pub const RESUMPTION_PSK_KID_LABEL: u8 = 16; // TODO: to be defined
 pub const ENC_STRUCTURE_LEN: usize = 8 + 5 + SHA256_DIGEST_LEN; // 8 for ENCRYPT0
 pub const ENC_STRUCTURE_PSK_LEN: usize = 1 + 1 + 8 + 1 + EXTERNAL_AAD_PSK_LEN; //
 pub const EXTERNAL_AAD_PSK_LEN: usize = 1 + 1 + 2 + 32 + 2 + 38 + 2 + 38 + 1;
@@ -183,6 +185,7 @@ pub type BufferCiphertext4 = EdhocMessageBuffer;
 pub type BytesHashLen = [u8; SHA256_DIGEST_LEN];
 pub type BytesP256ElemLen = [u8; P256_ELEM_LEN];
 pub type BytesElemLenPSK = [u8; ELEM_LEN_PSK];
+pub type BytesResumptionPsk = [u8; SHA256_DIGEST_LEN];
 pub type BufferMessage2 = EdhocMessageBuffer;
 /// Generic buffer type (soft-deprecated).
 ///
@@ -376,6 +379,12 @@ impl ConnId {
 pub enum EDHOCMethod {
     StatStat = 3,
     PSK = 4,
+}
+
+pub struct ResumptionPsk {
+    pub rpsk: BytesResumptionPsk,
+    pub kid: [u8; RESUMPTION_PSK_KID_LEN],
+    pub rid_cred_psk: IdCred,
 }
 
 impl TryFrom<u8> for EDHOCMethod {


### PR DESCRIPTION
This PR adds initial support for deriving EDHOC resumption material

Changes:
- Add resumption PSK constants and `BytesResumptionPsk`.
- Add `ResumptionPsk` result type containing `rPSK`, `rKID`, and `rID_CRED_PSK`.
- Add `IdCred::from_kid()` to construct `{ 4 : kid }` from raw kid bytes.
- Add `derive_resumption_psk()` for completed initiator and responder sessions.
- Add a test checking both peers derive matching resumption material.

Limitations:
- This PR only derives resumption material.
- A resumed PSK exchange is not wired yet because current PSK credentials are fixed to 16-byte symmetric keys, while `rPSK` is derived at hash length. This is fixed in PR #434 