### PR TITLE
Allow variable length PSKs

### DIFF
--- a/crypto/lakers-crypto-cryptocell310-sys/src/lib.rs
+++ b/crypto/lakers-crypto-cryptocell310-sys/src/lib.rs
@@ -80,10 +80,12 @@ impl CryptoTrait for Crypto {
         output
     }
 
-    fn hkdf_extract_psk(&mut self, salt: &BytesHashLen, ikm: &BytesElemLenPSK) -> BytesHashLen {
+    fn hkdf_extract_psk(&mut self, salt: &BytesHashLen, ikm: &BufferPsk) -> BytesHashLen {
         // TODO
         // TODO generalize if salt is not provided
-        let output = self.hmac_sha256(&mut ikm.clone()[..], *salt);
+        let mut psk = [0u8; MAX_PSK_LEN];
+        psk[..ikm.len()].copy_from_slice(ikm.as_slice());
+        let output = self.hmac_sha256(&mut psk[..ikm.len()], *salt);
 
         output
     }

--- a/crypto/lakers-crypto-cryptocell310-sys/src/lib.rs
+++ b/crypto/lakers-crypto-cryptocell310-sys/src/lib.rs
@@ -84,8 +84,8 @@ impl CryptoTrait for Crypto {
         // TODO
         // TODO generalize if salt is not provided
         let mut psk = [0u8; MAX_PSK_LEN];
-        psk[..ikm.len()].copy_from_slice(ikm.as_slice());
-        let output = self.hmac_sha256(&mut psk[..ikm.len()], *salt);
+        psk[..ikm.as_slice().len()].copy_from_slice(ikm.as_slice());
+        let output = self.hmac_sha256(&mut psk[..ikm.as_slice().len()], *salt);
 
         output
     }

--- a/crypto/lakers-crypto-psa/src/lib.rs
+++ b/crypto/lakers-crypto-psa/src/lib.rs
@@ -89,10 +89,10 @@ impl CryptoTrait for Crypto {
     }
 
     // added for PSK
-    fn hkdf_extract_psk(&mut self, salt: &BytesHashLen, ikm: &BytesElemLenPSK) -> BytesHashLen {
+    fn hkdf_extract_psk(&mut self, salt: &BytesHashLen, ikm: &BufferPsk) -> BytesHashLen {
         // TODO
         // TODO generalize if salt is not provided
-        let output = self.hmac_sha256(ikm, salt);
+        let output = self.hmac_sha256(ikm.as_slice(), salt);
 
         output
     }

--- a/crypto/lakers-crypto-rustcrypto/src/lib.rs
+++ b/crypto/lakers-crypto-rustcrypto/src/lib.rs
@@ -2,7 +2,7 @@
 
 use lakers_shared::CcmTagLen;
 use lakers_shared::{
-    BytesCcmIvLen, BytesCcmKeyLen, BytesElemLenPSK, BytesHashLen, BytesP256ElemLen,
+    BufferPsk, BytesCcmIvLen, BytesCcmKeyLen, BytesHashLen, BytesP256ElemLen,
     Crypto as CryptoTrait, EDHOCError, EDHOCSuite, EdhocBuffer, MAX_SUITES_LEN,
 };
 
@@ -74,11 +74,11 @@ impl<Rng: rand_core::RngCore + rand_core::CryptoRng> CryptoTrait for Crypto<Rng>
         extracted.finalize().0.into()
     }
 
-    fn hkdf_extract_psk(&mut self, salt: &BytesHashLen, ikm: &BytesElemLenPSK) -> BytesHashLen {
+    fn hkdf_extract_psk(&mut self, salt: &BytesHashLen, ikm: &BufferPsk) -> BytesHashLen {
         // While it'd be nice to just pass around an Hkdf, the extract output is not a type generic
         // of this trait (yet?).
         let mut extracted = hkdf::HkdfExtract::<sha2::Sha256>::new(Some(salt));
-        extracted.input_ikm(ikm);
+        extracted.input_ikm(ikm.as_slice());
         extracted.finalize().0.into()
     }
 

--- a/lakers-c/src/lib.rs
+++ b/lakers-c/src/lib.rs
@@ -232,7 +232,7 @@ impl ProcessingM2C {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug)]
 #[repr(C)]
 pub struct CredentialC {
     pub bytes: BufferCred,

--- a/lakers-c/src/lib.rs
+++ b/lakers-c/src/lib.rs
@@ -248,7 +248,7 @@ impl CredentialC {
     pub fn to_rust(&self) -> Credential {
         Credential {
             bytes: self.bytes.clone(),
-            key: self.key,
+            key: self.key.clone(),
             kid: Some(self.kid.clone()),
             cred_type: self.cred_type,
         }

--- a/lib/src/edhoc.rs
+++ b/lib/src/edhoc.rs
@@ -5,7 +5,7 @@ mod psk;
 mod statstat;
 
 use psk::{
-    i_parse_message_2_psk, i_prepare_message_3_psk, i_verify_message_2_psk, r_parse_message_3_psk,
+    i_parse_message_2_psk, i_prepare_message_3_psk, i_verify_message_2_psk,
     r_parse_message_3_psk_with_cred_resolver, r_prepare_message_2_psk, r_verify_message_3_psk,
 };
 use statstat::{
@@ -179,9 +179,7 @@ pub fn r_parse_message_3(
         WaitM3MethodSpecifics::StatStat { .. } => {
             r_parse_message_3_statstat(state, crypto, message_3)?
         }
-        WaitM3MethodSpecifics::Psk { cred_r } => {
-            r_parse_message_3_psk(state, crypto, message_3, cred_r)?
-        }
+        WaitM3MethodSpecifics::Psk { .. } => return Err(EDHOCError::UnsupportedMethod),
     };
 
     Ok((

--- a/lib/src/edhoc.rs
+++ b/lib/src/edhoc.rs
@@ -1097,7 +1097,7 @@ fn compute_prk_4e3m(
 fn compute_prk_4e3m_psk(
     crypto: &mut impl CryptoTrait,
     salt_4e3m: &BytesHashLen,
-    cred: &BytesElemLenPSK,
+    cred: &BufferPsk,
 ) -> BytesHashLen {
     crypto.hkdf_extract_psk(salt_4e3m, &cred)
 }
@@ -1926,8 +1926,28 @@ mod tests {
 
     #[test]
     fn test_compute_prk_4e3m_psk() {
-        let prk_4e3m = compute_prk_4e3m_psk(&mut default_crypto(), &SALT_4E3M_PSK_TV, &PSK_TV);
+        let psk = BufferPsk::new_from_slice(&PSK_TV)
+            .map_err(|_| EDHOCError::ParsingError)
+            .unwrap();
+        let prk_4e3m = compute_prk_4e3m_psk(&mut default_crypto(), &SALT_4E3M_PSK_TV, &psk);
         assert_eq!(prk_4e3m, PRK_4E3M_PSK_TV);
+    }
+
+    // fn test_compute_prk_4e3m_rpsk() {
+    //     let prk_4e3m = compute_prk_4e3m_psk(&mut default_crypto(), &SALT_4E3M_PSK_TV, &R_PSK_TV);
+    //     assert_eq!(prk_4e3m, PRK_4E3M_R_PSK_TV);
+    // }
+    #[test]
+    fn test_symmetric_32_bytes() {
+        let mut psk_32 = BufferPsk::new();
+        let mut psk_16 = BufferPsk::new();
+        psk_32.fill_with_slice(&[0xAB; 32]).unwrap();
+        psk_16.fill_with_slice(&[0xAB; 16]).unwrap();
+
+        let prk_32 = compute_prk_4e3m_psk(&mut default_crypto(), &SALT_4E3M_PSK_TV, &psk_32);
+        let prk_16 = compute_prk_4e3m_psk(&mut default_crypto(), &SALT_4E3M_PSK_TV, &psk_16);
+
+        assert_ne!(prk_32, prk_16);
     }
 
     #[test]

--- a/lib/src/edhoc.rs
+++ b/lib/src/edhoc.rs
@@ -1939,11 +1939,8 @@ mod tests {
     // }
     #[test]
     fn test_symmetric_32_bytes() {
-        let mut psk_32 = BufferPsk::new();
-        let mut psk_16 = BufferPsk::new();
-        psk_32.fill_with_slice(&[0xAB; 32]).unwrap();
-        psk_16.fill_with_slice(&[0xAB; 16]).unwrap();
-
+        let psk_32 = BufferPsk::new_from_slice(&[0xAB; 32]).unwrap();
+        let psk_16 = BufferPsk::new_from_slice(&[0xAB; 16]).unwrap();
         let prk_32 = compute_prk_4e3m_psk(&mut default_crypto(), &SALT_4E3M_PSK_TV, &psk_32);
         let prk_16 = compute_prk_4e3m_psk(&mut default_crypto(), &SALT_4E3M_PSK_TV, &psk_16);
 

--- a/lib/src/edhoc/psk.rs
+++ b/lib/src/edhoc/psk.rs
@@ -168,7 +168,7 @@ pub(crate) fn i_verify_message_2_psk(
     // message 3 processing
     let salt_4e3m = compute_salt_4e3m(crypto, &prk_3e2m, &th_3);
 
-    let psk = match valid_cred_r.key {
+    let psk = match &valid_cred_r.key {
         CredentialKey::Symmetric(psk) => psk,
         // FIXME: find a good definition of error
         _ => return Err(EDHOCError::UnsupportedMethod),

--- a/lib/src/edhoc/psk.rs
+++ b/lib/src/edhoc/psk.rs
@@ -35,26 +35,10 @@ pub(crate) fn r_prepare_message_2_psk(
     })
 }
 
-/// Parse PSK message 3 without external credential lookup.
+/// Parse PSK message 3, resolving `ID_CRED_PSK` through the caller-supplied `resolve_cred_i`.
 ///
-/// This succeeds when `ID_CRED_I` is sent by value.
-/// If the peer sends `ID_CRED_I` by reference, use
-/// `r_parse_message_3_psk_with_cred_resolver`.
-pub(crate) fn r_parse_message_3_psk(
-    state: &WaitM3,
-    crypto: &mut impl CryptoTrait,
-    message_3: &BufferMessage3,
-    cred_r: &Credential,
-) -> Result<ParsedMessage3, EDHOCError> {
-    r_parse_message_3_psk_with_cred_resolver(
-        state,
-        crypto,
-        message_3,
-        cred_r,
-        recover_cred_i_from_id_cred_psk,
-    )
-}
-
+/// PSK mode deliberately has no resolver-free variant: the PSK can only come from local storage,
+/// so the application has to supply the lookup.
 pub(crate) fn r_parse_message_3_psk_with_cred_resolver<F>(
     state: &WaitM3,
     crypto: &mut impl CryptoTrait,
@@ -72,6 +56,15 @@ where
         .any_as_encoded()
         .map_err(|_| EDHOCError::ParsingError)?;
     let id_cred_psk = IdCred::from_encoded_value(id_cred_psk_encoded)?;
+    // ID_CRED_PSK must merely *identify* a PSK we already hold; it may never carry the credential
+    // by value. Such a message would put the shared secret itself on the wire, and accepting it
+    // would let the peer pick the key this handshake authenticates with. Checked here, before
+    // `resolve_cred_i` runs, so that an application-supplied resolver cannot reintroduce the
+    // problem; `IdCred::get_ccs` enforces the same rule for direct callers of the credential
+    // lookup helpers.
+    if !id_cred_psk.reference_only() {
+        return Err(EDHOCError::WrongCredentialType);
+    }
     let ciphertext_3b_bytes = decoder
         .remaining_buffer()
         .map_err(|_| EDHOCError::ParsingError)?;
@@ -245,18 +238,4 @@ pub(crate) fn i_prepare_message_3_psk(
         },
     );
     Ok(PreparedMessage3 { message_3, th_4 })
-}
-
-/// Recover `CRED_I` directly from `ID_CRED_I` in PSK mode.
-///
-/// This only works when `ID_CRED_I` carries the credential by value.
-/// If `ID_CRED_I` is sent by reference (for example `kid`), callers need an
-/// external credential resolver and should use
-/// `r_parse_message_3_psk_with_cred_resolver`.
-fn recover_cred_i_from_id_cred_psk(id_cred_psk: &IdCred) -> Result<Credential, EDHOCError> {
-    if let Some(cred_i) = id_cred_psk.get_ccs() {
-        Ok(cred_i)
-    } else {
-        Err(EDHOCError::MissingIdentity)
-    }
 }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -194,6 +194,11 @@ impl<Crypto: CryptoTrait> EdhocResponderProcessedM1<Crypto> {
 }
 
 impl<'a, Crypto: CryptoTrait> EdhocResponderWaitM3<Crypto> {
+    /// Parse message 3, recovering `ID_CRED_I` without any credential lookup.
+    ///
+    /// Not supported for the PSK method, where it fails with `UnsupportedMethod`: resolving
+    /// `ID_CRED_PSK` requires a lookup against locally stored credentials, which this entry point
+    /// has no way to perform. Use [`Self::parse_message_3_with_credential_lookup`] instead.
     pub fn parse_message_3(
         mut self,
         message_3: &'a BufferMessage3,
@@ -574,11 +579,7 @@ pub fn credential_check_or_fetch(
         // 7. Store CRED_X as valid and trusted.
         //   Pair it with consistent credential identifiers, for each supported type of credential identifier.
 
-        if let Some(cred) = id_cred_received.get_ccs() {
-            Ok(cred)
-        } else {
-            Err(EDHOCError::ParsingError)
-        }
+        id_cred_received.get_ccs()
     }
 
     // 8. Is this authentication credential good to use in the context of this EDHOC session?
@@ -608,11 +609,7 @@ pub fn credential_lookup_or_fetch(
         }
     }
 
-    if let Some(cred) = id_cred_received.get_ccs() {
-        Ok(cred)
-    } else {
-        Err(EDHOCError::MissingIdentity)
-    }
+    id_cred_received.get_ccs()
 }
 
 #[cfg(test)]
@@ -641,11 +638,12 @@ mod test {
     use hexlit::hex;
     use lakers_crypto::default_crypto;
     use test_vectors_common::*;
-    #[cfg(feature = "test-ead-none")]
     const CRED_I_PSK: &[u8] =
         &hex!("A20269696E69746961746F7208A101A30104024110205050930FF462A77A3540CF546325DEA214");
     const CRED_R_PSK: &[u8] =
         &hex!("A20269726573706F6E64657208A101A30104024110205050930FF462A77A3540CF546325DEA214");
+    const CRED_I_PSK_FORGED: &[u8] =
+        &hex!("A20269696E69746961746F7208A101A301040241102050AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
 
     #[test]
     fn test_new_initiator() {
@@ -865,6 +863,61 @@ mod test {
     }
 
     #[test]
+    fn test_forged_cred_i_psk_credential_lookup_or_fetch() {
+        let cred_i = Credential::parse_ccs_symmetric(CRED_I_PSK.try_into().unwrap()).unwrap();
+
+        let mut id_cred_attacker = IdCred::new();
+        id_cred_attacker
+            .bytes
+            .extend_from_slice(&[CBOR_MAJOR_MAP + 1, KCCS_LABEL])
+            .map_err(|_| EDHOCError::CredentialTooLongError)
+            .unwrap();
+        id_cred_attacker
+            .bytes
+            .extend_from_slice(CRED_I_PSK_FORGED)
+            .unwrap();
+
+        let cred_fetch = credential_lookup_or_fetch(&[cred_i], id_cred_attacker);
+        assert!(matches!(cred_fetch, Err(EDHOCError::WrongCredentialType)))
+    }
+
+    #[test]
+    fn test_forged_cred_i_psk_credential_check_or_fetch() {
+        let cred_i = Credential::parse_ccs_symmetric(CRED_I_PSK.try_into().unwrap()).unwrap();
+
+        let mut id_cred_attacker = IdCred::new();
+        id_cred_attacker
+            .bytes
+            .extend_from_slice(&[CBOR_MAJOR_MAP + 1, KCCS_LABEL])
+            .map_err(|_| EDHOCError::CredentialTooLongError)
+            .unwrap();
+        id_cred_attacker
+            .bytes
+            .extend_from_slice(CRED_I_PSK_FORGED)
+            .unwrap();
+
+        let cred_fetch = credential_check_or_fetch(Some(cred_i), id_cred_attacker);
+        assert!(matches!(cred_fetch, Err(EDHOCError::UnexpectedCredential)))
+    }
+
+    #[test]
+    fn test_forged_cred_i_psk_credential_check_or_fetch_none() {
+        let mut id_cred_attacker = IdCred::new();
+        id_cred_attacker
+            .bytes
+            .extend_from_slice(&[CBOR_MAJOR_MAP + 1, KCCS_LABEL])
+            .map_err(|_| EDHOCError::CredentialTooLongError)
+            .unwrap();
+        id_cred_attacker
+            .bytes
+            .extend_from_slice(CRED_I_PSK_FORGED)
+            .unwrap();
+
+        let cred_fetch = credential_check_or_fetch(None, id_cred_attacker);
+        assert!(matches!(cred_fetch, Err(EDHOCError::WrongCredentialType)))
+    }
+
+    #[test]
     fn test_parse_message_3_empty_returns_error() {
         let cred_r = Credential::parse_ccs_symmetric(CRED_R_PSK.try_into().unwrap()).unwrap();
 
@@ -880,7 +933,9 @@ mod test {
             .unwrap();
 
         let empty_message_3 = BufferMessage3::new();
-        let err = responder.parse_message_3(&empty_message_3).unwrap_err();
+        let err = responder
+            .parse_message_3_with_credential_lookup(&empty_message_3, |_| unreachable!())
+            .unwrap_err();
         assert_eq!(err, EDHOCError::ParsingError);
     }
 }

--- a/shared/src/buffer.rs
+++ b/shared/src/buffer.rs
@@ -47,6 +47,7 @@ const fn copy_into_longer(long: &mut [u8], short: &[u8]) {
 pub enum EdhocBufferError {
     BufferAlreadyFull,
     SliceTooLong,
+    SliceTooShort,
 }
 
 /// A fixed-size (but parameterized) buffer for EDHOC messages.

--- a/shared/src/cred.rs
+++ b/shared/src/cred.rs
@@ -6,7 +6,7 @@ pub type BufferIdCred = EdhocBuffer<192>; // variable size, can contain either t
 pub type BytesKeyAES128 = [u8; 16];
 pub type BytesKeyEC2 = [u8; 32];
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug)]
 #[repr(C)]
 pub enum CredentialKey {
     Symmetric(BufferPsk),
@@ -167,7 +167,7 @@ impl IdCred {
 /// Experimental support for CCS_PSK credentials is also available.
 // TODO: add back support for C and Python bindings
 #[cfg_attr(feature = "python-bindings", pyclass(from_py_object))]
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug)]
 #[repr(C)]
 pub struct Credential {
     /// Original bytes of the credential, CBOR-encoded
@@ -355,9 +355,7 @@ impl Credential {
         }
         match (kty, x, k) {
             (Some(2), Some(x), None) => Ok((x, kid)),
-            (Some(4), None, Some(k)) if k.len() >= MIN_PSK_LEN => {
-                Ok((CredentialKey::Symmetric(k), kid))
-            }
+            (Some(4), None, Some(k)) => Ok((CredentialKey::Symmetric(k), kid)),
             _ => Err(EDHOCError::ParsingError),
         }
     }
@@ -382,6 +380,10 @@ impl Credential {
     pub fn parse_and_dress_naked_cosekey(cosekey: &[u8]) -> Result<Self, EDHOCError> {
         let mut decoder = CBORDecoder::new(cosekey);
         let (key, kid) = Self::parse_cosekey(&mut decoder)?;
+        let CredentialKey::EC2Compact(key) = key else {
+            return Err(EDHOCError::UnexpectedCredential);
+        };
+
         if !decoder.finished() {
             return Err(EDHOCError::ParsingError);
         }
@@ -394,7 +396,7 @@ impl Credential {
             .map_err(|_| EDHOCError::CredentialTooLongError)?;
         Ok(Self {
             bytes,
-            key,
+            key: CredentialKey::EC2Compact(key),
             kid,
             cred_type: CredentialType::CCS,
         })
@@ -481,10 +483,10 @@ mod test {
     fn test_parse_ccs() {
         let cred = Credential::parse_ccs(CRED_TV).unwrap();
         assert_eq!(cred.bytes.as_slice(), CRED_TV);
-        assert_eq!(
-            cred.key,
-            CredentialKey::EC2Compact(G_A_TV.try_into().unwrap())
-        );
+        let CredentialKey::EC2Compact(key) = cred.key else {
+            panic!("Expected EC2Compact credential");
+        };
+        assert_eq!(key.as_slice(), G_A_TV);
         assert_eq!(cred.kid.unwrap().as_slice(), KID_VALUE_TV);
         assert_eq!(cred.cred_type, CredentialType::CCS);
 
@@ -542,7 +544,10 @@ mod test_experimental {
     fn test_parse_ccs_psk_via_parse_ccs() {
         let cred = Credential::parse_ccs(CRED_PSK_16).unwrap();
         assert_eq!(cred.bytes.as_slice(), CRED_PSK_16);
-        assert_eq!(cred.key, CredentialKey::Symmetric(K_16.try_into().unwrap()));
+        let CredentialKey::Symmetric(key) = cred.key else {
+            panic!("Expected symmetric key")
+        };
+        assert_eq!(key.as_slice(), K_16);
         assert_eq!(cred.kid.unwrap().as_slice(), KID_VALUE_PSK);
         assert_eq!(cred.cred_type, CredentialType::CCS_PSK);
     }
@@ -554,7 +559,10 @@ mod test_experimental {
             .unwrap();
         let cred = Credential::new_ccs_symmetric(CRED_PSK_16.try_into().unwrap(), k.clone());
         assert_eq!(cred.bytes.as_slice(), CRED_PSK_16);
-        assert_eq!(cred.key, CredentialKey::Symmetric(k));
+        let CredentialKey::Symmetric(key) = cred.key else {
+            panic!("Expected symmetric key")
+        };
+        assert_eq!(key.as_slice(), k.as_slice());
     }
 
     #[test]
@@ -564,7 +572,10 @@ mod test_experimental {
             .unwrap();
         let cred = Credential::new_ccs_symmetric(CRED_PSK_32.try_into().unwrap(), k.clone());
         assert_eq!(cred.bytes.as_slice(), CRED_PSK_32);
-        assert_eq!(cred.key, CredentialKey::Symmetric(k));
+        let CredentialKey::Symmetric(key) = cred.key else {
+            panic!("Expected symmetric key")
+        };
+        assert_eq!(key.as_slice(), k.as_slice());
     }
 
     #[test]
@@ -574,7 +585,10 @@ mod test_experimental {
             .unwrap();
         let cred = Credential::parse_ccs_symmetric(CRED_PSK_16).unwrap();
         assert_eq!(cred.bytes.as_slice(), CRED_PSK_16);
-        assert_eq!(cred.key, CredentialKey::Symmetric(k));
+        let CredentialKey::Symmetric(key) = cred.key else {
+            panic!("Expected symmetric key")
+        };
+        assert_eq!(key.as_slice(), k.as_slice());
         assert_eq!(cred.kid.unwrap().as_slice(), KID_VALUE_PSK);
         assert_eq!(cred.cred_type, CredentialType::CCS_PSK);
     }
@@ -586,7 +600,10 @@ mod test_experimental {
             .unwrap();
         let cred = Credential::parse_ccs_symmetric(CRED_PSK_32).unwrap();
         assert_eq!(cred.bytes.as_slice(), CRED_PSK_32);
-        assert_eq!(cred.key, CredentialKey::Symmetric(k));
+        let CredentialKey::Symmetric(key) = cred.key else {
+            panic!("Expected symmetric key")
+        };
+        assert_eq!(key.as_slice(), k.as_slice());
         assert_eq!(cred.kid.unwrap().as_slice(), KID_VALUE_PSK);
         assert_eq!(cred.cred_type, CredentialType::CCS_PSK);
     }

--- a/shared/src/cred.rs
+++ b/shared/src/cred.rs
@@ -6,10 +6,10 @@ pub type BufferIdCred = EdhocBuffer<192>; // variable size, can contain either t
 pub type BytesKeyAES128 = [u8; 16];
 pub type BytesKeyEC2 = [u8; 32];
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 #[repr(C)]
 pub enum CredentialKey {
-    Symmetric(BytesKeyAES128),
+    Symmetric(BufferPsk),
     EC2Compact(BytesKeyEC2),
     // Add other key types as needed
 }
@@ -194,7 +194,7 @@ impl Credential {
     /// Creates a new CCS credential with the given bytes and a pre-shared key
     ///
     /// NOTE: For now this is only useful for the experimental PSK method.
-    pub fn new_ccs_symmetric(bytes: BufferCred, symmetric_key: BytesKeyAES128) -> Self {
+    pub fn new_ccs_symmetric(bytes: BufferCred, symmetric_key: BufferPsk) -> Self {
         Self {
             bytes,
             key: CredentialKey::Symmetric(symmetric_key),
@@ -273,16 +273,9 @@ impl Credential {
     pub fn parse_ccs_symmetric(value: &[u8]) -> Result<Self, EDHOCError> {
         const CCS_PREFIX_LEN: usize = 3;
         const CNF_AND_COSE_KEY_PREFIX_LEN: usize = 8;
-        const COSE_KEY_FIRST_ITEMS_LEN: usize = 3; //COSE for symmetric key
-        const SYMMETRIC_KEY_LEN: usize = 16; // Assuming a 128-bit symmetric key
+        const COSE_KEY_ITEMS_BEFORE_PSK_HEADER_LEN: usize = 2;
 
-        if value.len()
-            < CCS_PREFIX_LEN
-                + 1
-                + CNF_AND_COSE_KEY_PREFIX_LEN
-                + COSE_KEY_FIRST_ITEMS_LEN
-                + SYMMETRIC_KEY_LEN
-        {
+        if value.len() < CCS_PREFIX_LEN {
             Err(EDHOCError::ParsingError)
         } else {
             let subject_len = CBORDecoder::info_of(value[2]) as usize;
@@ -292,18 +285,45 @@ impl Credential {
                 .and_then(|x| x.checked_add(CNF_AND_COSE_KEY_PREFIX_LEN))
                 .ok_or(EDHOCError::ParsingError)?;
 
-            let symmetric_key_offset: usize = id_cred_offset
-                .checked_add(COSE_KEY_FIRST_ITEMS_LEN)
+            let psk_header_offset: usize = id_cred_offset
+                .checked_add(COSE_KEY_ITEMS_BEFORE_PSK_HEADER_LEN) // to get the PSK byte string header
                 .ok_or(EDHOCError::ParsingError)?;
 
-            if symmetric_key_offset
-                .checked_add(SYMMETRIC_KEY_LEN)
-                .map_or(false, |end| end <= value.len())
-            {
-                let symmetric_key: [u8; SYMMETRIC_KEY_LEN] = value
-                    [symmetric_key_offset..symmetric_key_offset + SYMMETRIC_KEY_LEN]
-                    .try_into()
-                    .map_err(|_| EDHOCError::ParsingError)?;
+            if value.len() <= psk_header_offset {
+                return Err(EDHOCError::ParsingError);
+            }
+
+            let header = value[psk_header_offset];
+
+            let (psk_len, psk_start) =
+                if header >= CBOR_MAJOR_BYTE_STRING && header <= CBOR_MAJOR_BYTE_STRING_MAX {
+                    (CBORDecoder::info_of(header) as usize, psk_header_offset + 1)
+                } else if header == CBOR_BYTE_STRING {
+                    let len_offset = psk_header_offset
+                        .checked_add(1)
+                        .ok_or(EDHOCError::ParsingError)?;
+
+                    if value.len() <= len_offset {
+                        return Err(EDHOCError::ParsingError);
+                    }
+
+                    (value[len_offset] as usize, psk_header_offset + 2)
+                } else {
+                    return Err(EDHOCError::ParsingError);
+                };
+
+            if psk_len == 0 || psk_len > MAX_PSK_LEN {
+                return Err(EDHOCError::ParsingError);
+            }
+            let psk_end = psk_start
+                .checked_add(psk_len)
+                .ok_or(EDHOCError::ParsingError)?;
+            if psk_end > value.len() {
+                return Err(EDHOCError::ParsingError);
+            } else {
+                let psk_bytes = &value[psk_start..psk_end];
+                let symmetric_key =
+                    BufferPsk::new_from_slice(psk_bytes).map_err(|_| EDHOCError::ParsingError)?;
 
                 let kid = value[id_cred_offset];
 
@@ -314,8 +334,6 @@ impl Credential {
                     kid: Some(BufferKid::new_from_slice(&[kid]).unwrap()),
                     cred_type: CredentialType::CCS_PSK,
                 })
-            } else {
-                Err(EDHOCError::ParsingError)
             }
         }
     }
@@ -476,7 +494,6 @@ mod test {
     const ID_CRED_BY_REF_TV: &[u8] = &hex!("a1044132");
     const ID_CRED_BY_VALUE_TV: &[u8] = &hex!("A10EA2026B6578616D706C652E65647508A101A501020241322001215820BBC34960526EA4D32E940CAD2A234148DDC21791A12AFBCBAC93622046DD44F02258204519E257236B2A0CE2023F0931F1F386CA7AFDA64FCDE0108C224C51EABF6072");
     const KID_VALUE_TV: &[u8] = &hex!("32");
-
     #[test]
     fn test_new_cred_ccs() {
         let cred = Credential::new_ccs(CRED_TV.try_into().unwrap(), G_A_TV.try_into().unwrap());
@@ -542,10 +559,13 @@ mod test_experimental {
     use super::*;
     use hexlit::hex;
 
-    const CRED_PSK: &[u8] =
+    const CRED_PSK_16: &[u8] =
         &hex!("A202686D79646F74626F7408A101A30104024132205050930FF462A77A3540CF546325DEA214");
-    const K: &[u8] = &hex!("50930FF462A77A3540CF546325DEA214");
+    const K_16: &[u8] = &hex!("50930FF462A77A3540CF546325DEA214");
     const KID_VALUE_PSK: &[u8] = &hex!("32");
+    const K_32: &[u8] = &hex!("50930FF462A77A3540CF546325DEA21450930FF462A77A3540CF546325DEA214");
+    const CRED_PSK_32: &[u8] =
+        &hex!("A202686D79646F74626F7408A101A3010402413220582050930FF462A77A3540CF546325DEA21450930FF462A77A3540CF546325DEA214");
 
     #[test]
     fn test_cred_ccs_symmetric_by_value_or_reference() {
@@ -553,17 +573,45 @@ mod test_experimental {
     }
 
     #[test]
-    fn test_new_cred_ccs_symmetric() {
-        let cred =
-            Credential::new_ccs_symmetric(CRED_PSK.try_into().unwrap(), K.try_into().unwrap());
-        assert_eq!(cred.bytes.as_slice(), CRED_PSK);
+    fn test_new_cred_ccs_symmetric_16() {
+        let k = BufferPsk::new_from_slice(&K_16)
+            .map_err(|_| EDHOCError::ParsingError)
+            .unwrap();
+        let cred = Credential::new_ccs_symmetric(CRED_PSK_16.try_into().unwrap(), k.clone());
+        assert_eq!(cred.bytes.as_slice(), CRED_PSK_16);
+        assert_eq!(cred.key, CredentialKey::Symmetric(k));
     }
 
     #[test]
-    fn test_parse_ccs_symmetric() {
-        let cred = Credential::parse_ccs_symmetric(CRED_PSK).unwrap();
-        assert_eq!(cred.bytes.as_slice(), CRED_PSK);
-        assert_eq!(cred.key, CredentialKey::Symmetric(K.try_into().unwrap()));
+    fn test_new_cred_ccs_symmetric_32() {
+        let k = BufferPsk::new_from_slice(&K_32)
+            .map_err(|_| EDHOCError::ParsingError)
+            .unwrap();
+        let cred = Credential::new_ccs_symmetric(CRED_PSK_32.try_into().unwrap(), k.clone());
+        assert_eq!(cred.bytes.as_slice(), CRED_PSK_32);
+        assert_eq!(cred.key, CredentialKey::Symmetric(k));
+    }
+
+    #[test]
+    fn test_parse_ccs_symmetric_16() {
+        let k = BufferPsk::new_from_slice(&K_16)
+            .map_err(|_| EDHOCError::ParsingError)
+            .unwrap();
+        let cred = Credential::parse_ccs_symmetric(CRED_PSK_16).unwrap();
+        assert_eq!(cred.bytes.as_slice(), CRED_PSK_16);
+        assert_eq!(cred.key, CredentialKey::Symmetric(k));
+        assert_eq!(cred.kid.unwrap().as_slice(), KID_VALUE_PSK);
+        assert_eq!(cred.cred_type, CredentialType::CCS_PSK);
+    }
+
+    #[test]
+    fn test_parse_ccs_symmetric_32() {
+        let k = BufferPsk::new_from_slice(&K_32)
+            .map_err(|_| EDHOCError::ParsingError)
+            .unwrap();
+        let cred = Credential::parse_ccs_symmetric(CRED_PSK_32).unwrap();
+        assert_eq!(cred.bytes.as_slice(), CRED_PSK_32);
+        assert_eq!(cred.key, CredentialKey::Symmetric(k));
         assert_eq!(cred.kid.unwrap().as_slice(), KID_VALUE_PSK);
         assert_eq!(cred.cred_type, CredentialType::CCS_PSK);
     }

--- a/shared/src/cred.rs
+++ b/shared/src/cred.rs
@@ -259,82 +259,27 @@ impl Credential {
             return Err(EDHOCError::ParsingError);
         }
 
+        let cred_type = match x {
+            CredentialKey::EC2Compact(_) => CredentialType::CCS,
+            CredentialKey::Symmetric(_) => CredentialType::CCS_PSK,
+        };
+
         Ok(Self {
             bytes: BufferCred::new_from_slice(value).map_err(|_| EDHOCError::ParsingError)?,
             key: x,
             kid,
-            cred_type: CredentialType::CCS,
+            cred_type,
         })
     }
 
     /// Parse a CCS style credential, but the key is a symmetric key.
-    ///
-    /// NOTE: For now this is only useful for the experimental PSK method.
     pub fn parse_ccs_symmetric(value: &[u8]) -> Result<Self, EDHOCError> {
-        const CCS_PREFIX_LEN: usize = 3;
-        const CNF_AND_COSE_KEY_PREFIX_LEN: usize = 8;
-        const COSE_KEY_ITEMS_BEFORE_PSK_HEADER_LEN: usize = 2;
-
-        if value.len() < CCS_PREFIX_LEN {
-            Err(EDHOCError::ParsingError)
-        } else {
-            let subject_len = CBORDecoder::info_of(value[2]) as usize;
-
-            let id_cred_offset: usize = CCS_PREFIX_LEN
-                .checked_add(subject_len)
-                .and_then(|x| x.checked_add(CNF_AND_COSE_KEY_PREFIX_LEN))
-                .ok_or(EDHOCError::ParsingError)?;
-
-            let psk_header_offset: usize = id_cred_offset
-                .checked_add(COSE_KEY_ITEMS_BEFORE_PSK_HEADER_LEN) // to get the PSK byte string header
-                .ok_or(EDHOCError::ParsingError)?;
-
-            if value.len() <= psk_header_offset {
-                return Err(EDHOCError::ParsingError);
-            }
-
-            let header = value[psk_header_offset];
-
-            let (psk_len, psk_start) =
-                if header >= CBOR_MAJOR_BYTE_STRING && header <= CBOR_MAJOR_BYTE_STRING_MAX {
-                    (CBORDecoder::info_of(header) as usize, psk_header_offset + 1)
-                } else if header == CBOR_BYTE_STRING {
-                    let len_offset = psk_header_offset
-                        .checked_add(1)
-                        .ok_or(EDHOCError::ParsingError)?;
-
-                    if value.len() <= len_offset {
-                        return Err(EDHOCError::ParsingError);
-                    }
-
-                    (value[len_offset] as usize, psk_header_offset + 2)
-                } else {
-                    return Err(EDHOCError::ParsingError);
-                };
-
-            if psk_len == 0 || psk_len > MAX_PSK_LEN {
-                return Err(EDHOCError::ParsingError);
-            }
-            let psk_end = psk_start
-                .checked_add(psk_len)
-                .ok_or(EDHOCError::ParsingError)?;
-            if psk_end > value.len() {
-                return Err(EDHOCError::ParsingError);
-            } else {
-                let psk_bytes = &value[psk_start..psk_end];
-                let symmetric_key =
-                    BufferPsk::new_from_slice(psk_bytes).map_err(|_| EDHOCError::ParsingError)?;
-
-                let kid = value[id_cred_offset];
-
-                Ok(Self {
-                    bytes: BufferCred::new_from_slice(value)
-                        .map_err(|_| EDHOCError::ParsingError)?,
-                    key: CredentialKey::Symmetric(symmetric_key),
-                    kid: Some(BufferKid::new_from_slice(&[kid]).unwrap()),
-                    cred_type: CredentialType::CCS_PSK,
-                })
-            }
+        // This function  checks whether the parsed credential actually contains a symmetric key
+        let cred = Self::parse_ccs(value)?;
+        match cred.cred_type {
+            CredentialType::CCS_PSK => Ok(cred),
+            // Anything that is not CCS_PSK is not a symmetric credential
+            _ => Err(EDHOCError::UnexpectedCredential),
         }
     }
 
@@ -343,21 +288,25 @@ impl Credential {
     /// This takes a decoder rather than a slice because this enables a naked decoder to assert that
     /// the decoder is done, and others to continue.
     ///
-    /// This function does not try to require deterministic encoding, as that is not exposed by the
-    /// decoder. (Adding it would be possible, but would not just mean asserting monotony, but also
-    /// requiring it integer encodings etc).
+    /// This function requires deterministic encoding, since kty has to appear before
+    /// -1 in order to decode adequately
     fn parse_cosekey<'data>(
         decoder: &mut CBORDecoder<'data>,
     ) -> Result<(CredentialKey, Option<BufferKid>), EDHOCError> {
         let items = decoder.map()?;
         let mut x = None;
         let mut kid = None;
+        let mut kty = None;
+        let mut k = None;
         for _ in 0..items {
             match decoder.i8()? {
                 // kty: EC2
                 1 => {
-                    if decoder.u8()? != 2 {
+                    let temp = decoder.u8()?;
+                    if temp != 2 && temp != 4 {
                         return Err(EDHOCError::ParsingError);
+                    } else {
+                        kty = Some(temp)
                     }
                 }
                 // kid: bytes. Note that this is always a byte string, even if in other places it's used
@@ -369,12 +318,22 @@ impl Credential {
                             .map_err(|_| EDHOCError::ParsingError)?,
                     );
                 }
-                // crv: p-256
-                -1 => {
-                    if decoder.u8()? != 1 {
-                        return Err(EDHOCError::ParsingError);
+                // Label -1 depends on kty: `crv` for EC2 keys, `k` (the key material
+                // itself) for symmetric keys. This is why kty has to be known by now.
+                -1 => match kty {
+                    Some(2) => {
+                        if decoder.u8()? != 1 {
+                            return Err(EDHOCError::ParsingError);
+                        }
                     }
-                }
+                    Some(4) => {
+                        k = Some(
+                            BufferPsk::new_from_slice(decoder.bytes()?)
+                                .map_err(|_| EDHOCError::ParsingError)?,
+                        );
+                    }
+                    _ => return Err(EDHOCError::ParsingError),
+                },
                 // x
                 -2 => {
                     x = Some(CredentialKey::EC2Compact(
@@ -394,7 +353,13 @@ impl Credential {
                 }
             }
         }
-        Ok((x.ok_or(EDHOCError::ParsingError)?, kid))
+        match (kty, x, k) {
+            (Some(2), Some(x), None) => Ok((x, kid)),
+            (Some(4), None, Some(k)) if k.len() >= MIN_PSK_LEN => {
+                Ok((CredentialKey::Symmetric(k), kid))
+            }
+            _ => Err(EDHOCError::ParsingError),
+        }
     }
 
     /// Dress a naked COSE_Key as a CCS by prepending 0xA108A101 as specified in Section 3.5.2 of
@@ -543,7 +508,8 @@ mod test {
     }
 
     #[rstest]
-    #[case(&[0x0D], &[0xa1, 0x04, 0x41, 0x0D])] // two optimizations: omit kid label and encode as CBOR integer
+    #[case(&[0x0D], &[0xa1, 0x04, 0x41, 0x0D]
+    )] // two optimizations: omit kid label and encode as CBOR integer
     #[case(&[0x41, 0x18], &[0xa1, 0x04, 0x41, 0x18])] // one optimization: omit kid label
     #[case(ID_CRED_BY_VALUE_TV, ID_CRED_BY_VALUE_TV)] // regular credential by value
     fn test_id_cred_from_encoded_plaintext(#[case] input: &[u8], #[case] expected: &[u8]) {
@@ -570,6 +536,15 @@ mod test_experimental {
     #[test]
     fn test_cred_ccs_symmetric_by_value_or_reference() {
         // TODO
+    }
+
+    #[test]
+    fn test_parse_ccs_psk_via_parse_ccs() {
+        let cred = Credential::parse_ccs(CRED_PSK_16).unwrap();
+        assert_eq!(cred.bytes.as_slice(), CRED_PSK_16);
+        assert_eq!(cred.key, CredentialKey::Symmetric(K_16.try_into().unwrap()));
+        assert_eq!(cred.kid.unwrap().as_slice(), KID_VALUE_PSK);
+        assert_eq!(cred.cred_type, CredentialType::CCS_PSK);
     }
 
     #[test]
@@ -614,5 +589,37 @@ mod test_experimental {
         assert_eq!(cred.key, CredentialKey::Symmetric(k));
         assert_eq!(cred.kid.unwrap().as_slice(), KID_VALUE_PSK);
         assert_eq!(cred.cred_type, CredentialType::CCS_PSK);
+    }
+
+    /// `CRED_PSK_16` with four trailing bytes that are not part of the CBOR item.
+    ///
+    /// The credential itself is well-formed; only the trailing data makes it invalid.
+    const CRED_PSK_16_TRAILING_GARBAGE: &[u8] = &hex!(
+        "A202686D79646F74626F7408A101A30104024132205050930FF462A77A3540CF546325DEA214DEADBEEF"
+    );
+
+    /// `CRED_PSK_16` with the COSE_Key entries reordered so that `-1` (k) precedes `1` (kty).
+    ///
+    /// This is valid CBOR, but not deterministically encoded: RFC 8949 orders map keys by their
+    /// encoded bytes, which puts `0x01` (kty) before `0x20` (-1).
+    const CRED_PSK_16_KTY_LAST: &[u8] =
+        &hex!("A202686D79646F74626F7408A101A3205050930FF462A77A3540CF546325DEA2140104024132");
+
+    /// `CRED_PSK_16` whose PSK is an empty byte string (`0x40`).
+    const CRED_PSK_EMPTY: &[u8] = &hex!("A202686D79646F74626F7408A101A301040241322040");
+
+    #[test]
+    fn test_parse_ccs_symmetric_rejects_trailing_garbage() {
+        Credential::parse_ccs_symmetric(CRED_PSK_16_TRAILING_GARBAGE).unwrap_err();
+    }
+
+    #[test]
+    fn test_parse_ccs_symmetric_rejects_kty_after_k() {
+        Credential::parse_ccs_symmetric(CRED_PSK_16_KTY_LAST).unwrap_err();
+    }
+
+    #[test]
+    fn test_parse_ccs_symmetric_rejects_empty_psk() {
+        Credential::parse_ccs_symmetric(CRED_PSK_EMPTY).unwrap_err();
     }
 }

--- a/shared/src/cred.rs
+++ b/shared/src/cred.rs
@@ -148,11 +148,31 @@ impl IdCred {
         self.bytes.as_slice()[1].into()
     }
 
-    pub fn get_ccs(&self) -> Option<Credential> {
+    /// Extract the credential this ID_CRED carries by value.
+    ///
+    /// A credential carrying a symmetric key (`CCS_PSK`) is never returned. Doing so would take
+    /// key material from the peer's own message instead of from local storage, letting the peer
+    /// choose the PSK that the handshake then "authenticates" with. This is the receive-side half
+    /// of the rule that [`Credential::by_value`] already enforces when sending.
+    ///
+    /// Errors with `MissingIdentity` if the ID_CRED is a reference (such as a `kid`) and so
+    /// carries no credential at all, `ParsingError` if the CCS is malformed, and
+    /// `WrongCredentialType` if it carries a symmetric key.
+    ///
+    /// Note that for the PSK method the same rule is enforced earlier, in
+    /// `r_parse_message_3_psk_with_cred_resolver`, which rejects a by-value `ID_CRED_PSK` before
+    /// any resolver runs. Neither check subsumes the other: that one protects handshakes that use
+    /// an application-supplied resolver, this one protects direct callers of
+    /// `credential_lookup_or_fetch` and `credential_check_or_fetch`.
+    pub fn get_ccs(&self) -> Result<Credential, EDHOCError> {
         if self.item_type() == IdCredType::KCCS {
-            Credential::parse_ccs(&self.bytes.as_slice()[2..]).ok()
+            let cred = Credential::parse_ccs(&self.bytes.as_slice()[2..])?;
+            match cred.cred_type {
+                CredentialType::CCS => Ok(cred),
+                _ => Err(EDHOCError::WrongCredentialType),
+            }
         } else {
-            None
+            Err(EDHOCError::MissingIdentity)
         }
     }
 

--- a/shared/src/crypto.rs
+++ b/shared/src/crypto.rs
@@ -61,7 +61,7 @@ pub trait Crypto: core::fmt::Debug {
     fn sha256_start<'a>(&'a mut self) -> Self::HashInProcess<'a>;
     fn hkdf_expand(&mut self, prk: &BytesHashLen, info: &[u8], result: &mut [u8]);
     fn hkdf_extract(&mut self, salt: &BytesHashLen, ikm: &BytesP256ElemLen) -> BytesHashLen;
-    fn hkdf_extract_psk(&mut self, salt: &BytesHashLen, ikm: &BytesElemLenPSK) -> BytesHashLen;
+    fn hkdf_extract_psk(&mut self, salt: &BytesHashLen, ikm: &BufferPsk) -> BytesHashLen;
     fn aes_ccm_encrypt<const N: usize, TagLen: CcmTagLen>(
         &mut self,
         key: &BytesCcmKeyLen,

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -114,10 +114,10 @@ pub const CBOR_MAJOR_ARRAY: u8 = 0x80u8;
 pub const CBOR_MAJOR_ARRAY_MAX: u8 = 0x97u8;
 pub const CBOR_MAJOR_MAP: u8 = 0xA0;
 pub const MAX_INFO_LEN: usize = 2 + SHA256_DIGEST_LEN + // 32-byte digest as bstr
-				            1 + MAX_KDF_LABEL_LEN +     // label <24 bytes as tstr
-						    1 + MAX_KDF_CONTEXT_LEN +   // context <24 bytes as bstr
-						    1; // length as u8
-
+    1 + MAX_KDF_LABEL_LEN +     // label <24 bytes as tstr
+    1 + MAX_KDF_CONTEXT_LEN +   // context <24 bytes as bstr
+    1; // length as u8
+pub const MAX_PSK_LEN: usize = SHA256_DIGEST_LEN;
 pub const KCCS_LABEL: u8 = 14;
 #[deprecated(note = "Typo for KCCS_LABEL")]
 pub const KCSS_LABEL: u8 = KCCS_LABEL;
@@ -174,6 +174,7 @@ pub type BufferMessage3 = EdhocMessageBuffer;
 pub type BufferMessage4 = EdhocMessageBuffer;
 pub type BufferCiphertext2 = EdhocMessageBuffer;
 pub type BufferCiphertext3 = EdhocMessageBuffer;
+pub type BufferPsk = EdhocBuffer<MAX_PSK_LEN>;
 pub type BufferCiphertext4 = EdhocMessageBuffer;
 pub type BytesHashLen = [u8; SHA256_DIGEST_LEN];
 pub type BytesP256ElemLen = [u8; P256_ELEM_LEN];

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -417,6 +417,14 @@ pub enum EDHOCError {
     /// error: When the application sets the expected credential, that process should be informed
     /// by the known details.
     UnexpectedCredential,
+    /// A credential was well formed, but of a type that may not be used the way it was presented:
+    /// in particular a credential carrying a symmetric key (a PSK), sent by value rather than
+    /// identified by reference.
+    ///
+    /// Unlike [`EDHOCError::UnexpectedCredential`] this does not depend on what the application
+    /// was expecting. Such a credential is refused unconditionally, because honouring it would
+    /// mean deriving key material from the peer's own message.
+    WrongCredentialType,
     MissingIdentity,
     IdentityAlreadySet,
     MacVerificationFailed,
@@ -456,6 +464,7 @@ impl EDHOCError {
         use EDHOCError::*;
         match self {
             UnexpectedCredential => ErrCode::UNSPECIFIED,
+            WrongCredentialType => ErrCode::UNSPECIFIED,
             MissingIdentity => ErrCode::UNSPECIFIED,
             IdentityAlreadySet => ErrCode::UNSPECIFIED,
             MacVerificationFailed => ErrCode::UNSPECIFIED,

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -29,6 +29,8 @@ pub use buffer::*;
 
 #[cfg(feature = "python-bindings")]
 use pyo3::prelude::*;
+mod psk;
+pub use psk::*;
 #[cfg(feature = "python-bindings")]
 mod python_bindings;
 
@@ -117,7 +119,9 @@ pub const MAX_INFO_LEN: usize = 2 + SHA256_DIGEST_LEN + // 32-byte digest as bst
     1 + MAX_KDF_LABEL_LEN +     // label <24 bytes as tstr
     1 + MAX_KDF_CONTEXT_LEN +   // context <24 bytes as bstr
     1; // length as u8
-pub const MAX_PSK_LEN: usize = SHA256_DIGEST_LEN; // arbitrary chosen number
+       // The PSK is the IKM of an HKDF-SHA-256 extract, whose output is a 256-bit PRK, so entropy beyond
+       // 32 bytes cannot be carried into the key schedule and a longer PSK buys no additional security.
+pub const MAX_PSK_LEN: usize = SHA256_DIGEST_LEN;
 pub const MIN_PSK_LEN: usize = 16; // Each external PSK MUST be derived from at least 128 bits of entropy, and MUST be at least 128 bits long
 pub const KCCS_LABEL: u8 = 14;
 #[deprecated(note = "Typo for KCCS_LABEL")]
@@ -175,7 +179,6 @@ pub type BufferMessage3 = EdhocMessageBuffer;
 pub type BufferMessage4 = EdhocMessageBuffer;
 pub type BufferCiphertext2 = EdhocMessageBuffer;
 pub type BufferCiphertext3 = EdhocMessageBuffer;
-pub type BufferPsk = EdhocBuffer<MAX_PSK_LEN>; // TODO: is a secret, and EdhocBuffer implements Debug. To change
 pub type BufferCiphertext4 = EdhocMessageBuffer;
 pub type BytesHashLen = [u8; SHA256_DIGEST_LEN];
 pub type BytesP256ElemLen = [u8; P256_ELEM_LEN];
@@ -214,6 +217,7 @@ pub type EADBuffer = EdhocBuffer<MAX_EAD_LEN>;
 /// string or a number in -24..=23, all in preferred encoding.
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub struct ConnId([u8; MAX_CONNID_ENCODED_LEN]);
+// Secret key material and must not be printable or comparable
 
 /// Classifier for the content of [`ConnId`]; used internally in its implementation.
 enum ConnIdType {

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -117,7 +117,8 @@ pub const MAX_INFO_LEN: usize = 2 + SHA256_DIGEST_LEN + // 32-byte digest as bst
     1 + MAX_KDF_LABEL_LEN +     // label <24 bytes as tstr
     1 + MAX_KDF_CONTEXT_LEN +   // context <24 bytes as bstr
     1; // length as u8
-pub const MAX_PSK_LEN: usize = SHA256_DIGEST_LEN;
+pub const MAX_PSK_LEN: usize = SHA256_DIGEST_LEN; // arbitrary chosen number
+pub const MIN_PSK_LEN: usize = 16; // Each external PSK MUST be derived from at least 128 bits of entropy, and MUST be at least 128 bits long
 pub const KCCS_LABEL: u8 = 14;
 #[deprecated(note = "Typo for KCCS_LABEL")]
 pub const KCSS_LABEL: u8 = KCCS_LABEL;
@@ -174,7 +175,7 @@ pub type BufferMessage3 = EdhocMessageBuffer;
 pub type BufferMessage4 = EdhocMessageBuffer;
 pub type BufferCiphertext2 = EdhocMessageBuffer;
 pub type BufferCiphertext3 = EdhocMessageBuffer;
-pub type BufferPsk = EdhocBuffer<MAX_PSK_LEN>;
+pub type BufferPsk = EdhocBuffer<MAX_PSK_LEN>; // TODO: is a secret, and EdhocBuffer implements Debug. To change
 pub type BufferCiphertext4 = EdhocMessageBuffer;
 pub type BytesHashLen = [u8; SHA256_DIGEST_LEN];
 pub type BytesP256ElemLen = [u8; P256_ELEM_LEN];

--- a/shared/src/psk.rs
+++ b/shared/src/psk.rs
@@ -1,0 +1,47 @@
+use crate::{EdhocBuffer, EdhocBufferError, MAX_PSK_LEN, MIN_PSK_LEN};
+
+/// A pre-shared key for the EDHOC PSK method.
+///
+/// This wraps an [`EdhocBuffer`] rather than being an alias for one, so that the key material is
+/// covered by two guarantees that a bare buffer cannot give:
+///
+/// * **It is at least [`MIN_PSK_LEN`] bytes long.** The only way to obtain a value of this type is
+///   [`BufferPsk::new_from_slice`], which rejects anything shorter, so no code path can produce a
+///   PSK with insufficient entropy.
+/// * **It does not reveal the key material.** A derived `Debug` would let the key leak into logs
+///   and panic messages, so `Debug` is implemented by hand and prints only a redaction marker. A
+///   derived `PartialEq` would compare the key in non-constant time, leaking it through a timing
+///   side channel, so it is not implemented at all. The inner buffer is private so that neither
+///   can be reached through it. `Clone` *is* implemented: duplicating a key reveals nothing, it
+///   only affects how many copies are in memory. Do not turn the other two into derives.
+///
+/// Note that this type does not yet erase the key material when it is dropped, so the key remains
+/// readable in memory afterwards (in as many places as it was cloned into). See the TODO below.
+
+// TODO: BufferPsk does not erase key material on drop, and Clone can leave multiple copies in memory.
+// Fix with zeroize.
+#[derive(Clone)]
+#[repr(C)]
+pub struct BufferPsk {
+    inner: EdhocBuffer<MAX_PSK_LEN>,
+}
+impl BufferPsk {
+    pub const fn new_from_slice(slice: &[u8]) -> Result<Self, EdhocBufferError> {
+        if slice.len() < MIN_PSK_LEN {
+            return Err(EdhocBufferError::SliceTooShort);
+        }
+        match EdhocBuffer::new_from_slice(slice) {
+            Ok(inner) => Ok(Self { inner }),
+            Err(e) => Err(e),
+        }
+    }
+    pub fn as_slice(&self) -> &[u8] {
+        self.inner.as_slice()
+    }
+}
+
+impl core::fmt::Debug for BufferPsk {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("BufferPsk(<redacted>)")
+    }
+}


### PR DESCRIPTION
Allow variable length PSKs (before it was hardcoded, but this is a problem when introducing resumption keys)

- Replace fixed-size PSK storage with BufferPsk.
- Parse CCS symmetric keys using the encoded CBOR byte-string length.
- Update RustCrypto, PSA, and cryptocell310 crypto backend trait implementations.
- Fix C wrapper credential conversion after CredentialKey stopped being Copy.