### PR TITLE
PSK: remove now unused consts 

### DIFF
--- a/shared/src/cred.rs
+++ b/shared/src/cred.rs
@@ -3,7 +3,6 @@ use super::*;
 pub type BufferCred = EdhocBuffer<192>; // arbitrary size
 pub type BufferKid = EdhocBuffer<16>; // variable size, up to 16 bytes
 pub type BufferIdCred = EdhocBuffer<192>; // variable size, can contain either the contents of a BufferCred or a BufferKid
-pub type BytesKeyAES128 = [u8; 16];
 pub type BytesKeyEC2 = [u8; 32];
 
 #[derive(Clone, Debug)]

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -121,7 +121,7 @@ pub const MAX_INFO_LEN: usize = 2 + SHA256_DIGEST_LEN + // 32-byte digest as bst
     1; // length as u8
        // The PSK is the IKM of an HKDF-SHA-256 extract, whose output is a 256-bit PRK, so entropy beyond
        // 32 bytes cannot be carried into the key schedule and a longer PSK buys no additional security.
-pub const MAX_PSK_LEN: usize = SHA256_DIGEST_LEN;
+pub const MAX_PSK_LEN: usize = 32; // arbitrary chosen number
 pub const MIN_PSK_LEN: usize = 16; // Each external PSK MUST be derived from at least 128 bits of entropy, and MUST be at least 128 bits long
 pub const KCCS_LABEL: u8 = 14;
 #[deprecated(note = "Typo for KCCS_LABEL")]

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -57,7 +57,6 @@ pub const SUITES_LEN: usize = 9;
 pub const SUPPORTED_SUITES_LEN: usize = 1;
 pub const EDHOC_METHOD: u8 = 3u8; // stat-stat is the only supported method
 pub const P256_ELEM_LEN: usize = 32;
-pub const ELEM_LEN_PSK: usize = 16;
 pub const SHA256_DIGEST_LEN: usize = 32;
 pub const AES_CCM_KEY_LEN: usize = 16;
 pub const AES_CCM_IV_LEN: usize = 13;
@@ -182,7 +181,6 @@ pub type BufferCiphertext3 = EdhocMessageBuffer;
 pub type BufferCiphertext4 = EdhocMessageBuffer;
 pub type BytesHashLen = [u8; SHA256_DIGEST_LEN];
 pub type BytesP256ElemLen = [u8; P256_ELEM_LEN];
-pub type BytesElemLenPSK = [u8; ELEM_LEN_PSK];
 pub type BufferMessage2 = EdhocMessageBuffer;
 /// Generic buffer type (soft-deprecated).
 ///


### PR DESCRIPTION
Remove unused consts and make `MAX_PSK_LEN` explicitly not bound to `SHA256_DIGEST_LEN`